### PR TITLE
Make this run on Macs -

### DIFF
--- a/app/command_router.go
+++ b/app/command_router.go
@@ -14,16 +14,14 @@ func CommandRouter(c *cli.Context) {
 		ListPackages(c.String("release"))
 	case c.Command.FullName() == "compilation build-base":
 		CreateBaseCompilationImage(
-			c.String("docker-endpoint"),
 			c.String("base-image"),
 			c.String("release"),
 			c.String("repository"),
 		)
 	case c.Command.FullName() == "compilation show-base":
-		ShowBaseImage(c.String("docker-endpoint"), c.String("base-image"))
+		ShowBaseImage(c.String("base-image"))
 	case c.Command.FullName() == "compilation start":
 		Compile(
-			c.String("docker-endpoint"),
 			c.String("base-image"),
 			c.String("release"),
 			c.String("repository"),

--- a/app/fissile.go
+++ b/app/fissile.go
@@ -194,8 +194,8 @@ func PrintTemplateReport(releasePath string) {
 }
 
 // ShowBaseImage will show details about the base BOSH image
-func ShowBaseImage(dockerEndpoint, baseImage string) {
-	dockerManager, err := docker.NewImageManager(dockerEndpoint)
+func ShowBaseImage(baseImage string) {
+	dockerManager, err := docker.NewImageManager()
 	if err != nil {
 		log.Fatalln(color.RedString("Error connecting to docker: %s", err.Error()))
 	}
@@ -210,8 +210,8 @@ func ShowBaseImage(dockerEndpoint, baseImage string) {
 }
 
 // CreateBaseCompilationImage will recompile the base BOSH image for a release
-func CreateBaseCompilationImage(dockerEndpoint, baseImageName, releasePath, repository string) {
-	dockerManager, err := docker.NewImageManager(dockerEndpoint)
+func CreateBaseCompilationImage(baseImageName, releasePath, repository string) {
+	dockerManager, err := docker.NewImageManager()
 	if err != nil {
 		log.Fatalln(color.RedString("Error connecting to docker: %s", err.Error()))
 	}
@@ -246,8 +246,8 @@ func CreateBaseCompilationImage(dockerEndpoint, baseImageName, releasePath, repo
 }
 
 // Compile will compile a full BOSH release
-func Compile(dockerEndpoint, baseImageName, releasePath, repository, targetPath string, workerCount int) {
-	dockerManager, err := docker.NewImageManager(dockerEndpoint)
+func Compile(baseImageName, releasePath, repository, targetPath string, workerCount int) {
+	dockerManager, err := docker.NewImageManager()
 	if err != nil {
 		log.Fatalln(color.RedString("Error connecting to docker: %s", err.Error()))
 	}

--- a/compilator/compilator.go
+++ b/compilator/compilator.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -14,6 +13,7 @@ import (
 	"github.com/hpcloud/fissile/docker"
 	"github.com/hpcloud/fissile/model"
 	"github.com/hpcloud/fissile/scripts/compilation"
+	"github.com/hpcloud/fissile/util"
 
 	"github.com/fatih/color"
 	dockerClient "github.com/fsouza/go-dockerclient"
@@ -201,7 +201,7 @@ func (c *Compilator) CreateCompilationBase(baseImageName string) (image *dockerC
 		return image, nil
 	}
 
-	tempScriptDir, err := ioutil.TempDir("", "fissile-compilation")
+	tempScriptDir, err := util.TempDir("", "fissile-compilation")
 	if err != nil {
 		return nil, fmt.Errorf("Could not create temp dir %s: %s", tempScriptDir, err.Error())
 	}

--- a/compilator/compilator_test.go
+++ b/compilator/compilator_test.go
@@ -11,28 +11,21 @@ import (
 	"github.com/hpcloud/fissile/docker"
 	"github.com/hpcloud/fissile/model"
 	"github.com/hpcloud/fissile/scripts/compilation"
+	"github.com/hpcloud/fissile/util"
 
 	"code.google.com/p/go-uuid/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 const (
-	dockerEndpointEnvVar      = "FISSILE_TEST_DOCKER_ENDPOINT"
-	defaultDockerTestEndpoint = "unix:///var/run/docker.sock"
-	dockerImageEnvVar         = "FISSILE_TEST_DOCKER_IMAGE"
-	defaultDockerTestImage    = "ubuntu:14.04"
+	dockerImageEnvVar      = "FISSILE_TEST_DOCKER_IMAGE"
+	defaultDockerTestImage = "ubuntu:14.04"
 )
 
-var dockerEndpoint string
 var dockerImageName string
 
 func TestMain(m *testing.M) {
 	log.SetOutput(ioutil.Discard)
-
-	dockerEndpoint = os.Getenv(dockerEndpointEnvVar)
-	if dockerEndpoint == "" {
-		dockerEndpoint = defaultDockerTestEndpoint
-	}
 
 	dockerImageName = os.Getenv(dockerImageEnvVar)
 	if dockerImageName == "" {
@@ -53,10 +46,10 @@ func TestCompilationSourcePreparation(t *testing.T) {
 func TestGetPackageStatusCompiled(t *testing.T) {
 	assert := assert.New(t)
 
-	compilationWorkDir, err := ioutil.TempDir("", "fissile-tests")
+	compilationWorkDir, err := util.TempDir("", "fissile-tests")
 	assert.Nil(err)
 
-	dockerManager, err := docker.NewImageManager(dockerEndpoint)
+	dockerManager, err := docker.NewImageManager()
 	assert.Nil(err)
 
 	workDir, err := os.Getwd()
@@ -83,10 +76,10 @@ func TestGetPackageStatusCompiled(t *testing.T) {
 func TestGetPackageStatusNone(t *testing.T) {
 	assert := assert.New(t)
 
-	compilationWorkDir, err := ioutil.TempDir("", "fissile-tests")
+	compilationWorkDir, err := util.TempDir("", "fissile-tests")
 	assert.Nil(err)
 
-	dockerManager, err := docker.NewImageManager(dockerEndpoint)
+	dockerManager, err := docker.NewImageManager()
 	assert.Nil(err)
 
 	workDir, err := os.Getwd()
@@ -106,10 +99,10 @@ func TestGetPackageStatusNone(t *testing.T) {
 func TestPackageFolderStructure(t *testing.T) {
 	assert := assert.New(t)
 
-	compilationWorkDir, err := ioutil.TempDir("", "fissile-tests")
+	compilationWorkDir, err := util.TempDir("", "fissile-tests")
 	assert.Nil(err)
 
-	dockerManager, err := docker.NewImageManager(dockerEndpoint)
+	dockerManager, err := docker.NewImageManager()
 	assert.Nil(err)
 
 	workDir, err := os.Getwd()
@@ -135,10 +128,10 @@ func TestPackageFolderStructure(t *testing.T) {
 func TestPackageDependenciesPreparation(t *testing.T) {
 	assert := assert.New(t)
 
-	compilationWorkDir, err := ioutil.TempDir("", "fissile-tests")
+	compilationWorkDir, err := util.TempDir("", "fissile-tests")
 	assert.Nil(err)
 
-	dockerManager, err := docker.NewImageManager(dockerEndpoint)
+	dockerManager, err := docker.NewImageManager()
 	assert.Nil(err)
 
 	workDir, err := os.Getwd()
@@ -173,10 +166,10 @@ func TestPackageDependenciesPreparation(t *testing.T) {
 func TestCompilePackage(t *testing.T) {
 	assert := assert.New(t)
 
-	compilationWorkDir, err := ioutil.TempDir("", "fissile-tests")
+	compilationWorkDir, err := util.TempDir("", "fissile-tests")
 	assert.Nil(err)
 
-	dockerManager, err := docker.NewImageManager(dockerEndpoint)
+	dockerManager, err := docker.NewImageManager()
 	assert.Nil(err)
 
 	workDir, err := os.Getwd()
@@ -191,6 +184,7 @@ func TestCompilePackage(t *testing.T) {
 
 	imageTag := comp.BaseCompilationImageTag()
 	imageName := fmt.Sprintf("%s:%s", comp.DockerRepository, imageTag)
+
 	_, err = comp.CreateCompilationBase(dockerImageName)
 	defer func() {
 		err = dockerManager.RemoveImage(imageName)

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -20,18 +20,14 @@ type ProcessOutStream func(io.Reader)
 
 // ImageManager handles Docker images
 type ImageManager struct {
-	DockerEndpoint string
-
 	client *dockerclient.Client
 }
 
 // NewImageManager creates an instance of ImageManager
-func NewImageManager(dockerEndpoint string) (*ImageManager, error) {
-	manager := &ImageManager{
-		DockerEndpoint: dockerEndpoint,
-	}
+func NewImageManager() (*ImageManager, error) {
+	manager := &ImageManager{}
 
-	client, err := dockerclient.NewClient(manager.DockerEndpoint)
+	client, err := dockerclient.NewClientFromEnv()
 	manager.client = client
 
 	if err != nil {

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -13,21 +13,13 @@ import (
 )
 
 const (
-	dockerEndpointEnvVar      = "FISSILE_TEST_DOCKER_ENDPOINT"
-	defaultDockerTestEndpoint = "unix:///var/run/docker.sock"
-	dockerImageEnvVar         = "FISSILE_TEST_DOCKER_IMAGE"
-	defaultDockerTestImage    = "ubuntu:14.04"
+	dockerImageEnvVar      = "FISSILE_TEST_DOCKER_IMAGE"
+	defaultDockerTestImage = "ubuntu:14.04"
 )
 
-var dockerEndpoint string
 var dockerImageName string
 
 func TestMain(m *testing.M) {
-	dockerEndpoint = os.Getenv(dockerEndpointEnvVar)
-	if dockerEndpoint == "" {
-		dockerEndpoint = defaultDockerTestEndpoint
-	}
-
 	dockerImageName = os.Getenv(dockerImageEnvVar)
 	if dockerImageName == "" {
 		dockerImageName = defaultDockerTestImage
@@ -41,7 +33,7 @@ func TestMain(m *testing.M) {
 func TestFindImageOK(t *testing.T) {
 	assert := assert.New(t)
 
-	dockerManager, err := NewImageManager(dockerEndpoint)
+	dockerManager, err := NewImageManager()
 	assert.Nil(err)
 
 	image, err := dockerManager.FindImage(dockerImageName)
@@ -53,7 +45,7 @@ func TestFindImageOK(t *testing.T) {
 func TestShowImageNotOK(t *testing.T) {
 	assert := assert.New(t)
 
-	dockerManager, err := NewImageManager(dockerEndpoint)
+	dockerManager, err := NewImageManager()
 	assert.Nil(err)
 
 	_, err = dockerManager.FindImage(uuid.New())
@@ -65,7 +57,7 @@ func TestShowImageNotOK(t *testing.T) {
 func TestRunInContainer(t *testing.T) {
 	assert := assert.New(t)
 
-	dockerManager, err := NewImageManager(dockerEndpoint)
+	dockerManager, err := NewImageManager()
 
 	assert.Nil(err)
 
@@ -96,7 +88,7 @@ func TestRunInContainer(t *testing.T) {
 func TestRunInContainerStderr(t *testing.T) {
 	assert := assert.New(t)
 
-	dockerManager, err := NewImageManager(dockerEndpoint)
+	dockerManager, err := NewImageManager()
 
 	assert.Nil(err)
 
@@ -127,7 +119,7 @@ func TestRunInContainerStderr(t *testing.T) {
 func TestRunInContainerWithInFiles(t *testing.T) {
 	assert := assert.New(t)
 
-	dockerManager, err := NewImageManager(dockerEndpoint)
+	dockerManager, err := NewImageManager()
 
 	assert.Nil(err)
 
@@ -158,7 +150,7 @@ func TestRunInContainerWithInFiles(t *testing.T) {
 func TestRunInContainerWithReadOnlyInFiles(t *testing.T) {
 	assert := assert.New(t)
 
-	dockerManager, err := NewImageManager(dockerEndpoint)
+	dockerManager, err := NewImageManager()
 
 	assert.Nil(err)
 
@@ -182,7 +174,7 @@ func TestRunInContainerWithReadOnlyInFiles(t *testing.T) {
 func TestRunInContainerWithOutFiles(t *testing.T) {
 	assert := assert.New(t)
 
-	dockerManager, err := NewImageManager(dockerEndpoint)
+	dockerManager, err := NewImageManager()
 
 	assert.Nil(err)
 
@@ -213,7 +205,7 @@ func TestRunInContainerWithOutFiles(t *testing.T) {
 func TestRunInContainerWithWritableOutFiles(t *testing.T) {
 	assert := assert.New(t)
 
-	dockerManager, err := NewImageManager(dockerEndpoint)
+	dockerManager, err := NewImageManager()
 
 	assert.Nil(err)
 
@@ -237,7 +229,7 @@ func TestRunInContainerWithWritableOutFiles(t *testing.T) {
 func TestCreateImageOk(t *testing.T) {
 	assert := assert.New(t)
 
-	dockerManager, err := NewImageManager(dockerEndpoint)
+	dockerManager, err := NewImageManager()
 
 	assert.Nil(err)
 

--- a/main.go
+++ b/main.go
@@ -82,11 +82,6 @@ func main() {
 					Aliases: []string{"bb"},
 					Flags: []cli.Flag{
 						cli.StringFlag{
-							Name:  "docker-endpoint, d",
-							Value: "unix:///var/run/docker.sock",
-							Usage: "Docker endpoint.",
-						},
-						cli.StringFlag{
 							Name:  "base-image, b",
 							Value: "ubuntu:14.04",
 							Usage: "Base image.",
@@ -110,11 +105,6 @@ func main() {
 					Aliases: []string{"sb"},
 					Flags: []cli.Flag{
 						cli.StringFlag{
-							Name:  "docker-endpoint, d",
-							Value: "unix:///var/run/docker.sock",
-							Usage: "Docker endpoint.",
-						},
-						cli.StringFlag{
 							Name:  "base-image, b",
 							Value: "ubuntu:14.04",
 							Usage: "Base image.",
@@ -127,11 +117,6 @@ func main() {
 					Name:    "start",
 					Aliases: []string{"st"},
 					Flags: []cli.Flag{
-						cli.StringFlag{
-							Name:  "docker-endpoint, d",
-							Value: "unix:///var/run/docker.sock",
-							Usage: "Docker endpoint.",
-						},
 						cli.StringFlag{
 							Name:  "base-image, b",
 							Value: "ubuntu:14.04",

--- a/scripts/compilation/compilation.go
+++ b/scripts/compilation/compilation.go
@@ -86,7 +86,7 @@ func scriptsCompilationFakeCompileSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "scripts/compilation/fake-compile.sh", size: 6, mode: os.FileMode(436), modTime: time.Unix(1443218238, 0)}
+	info := bindataFileInfo{name: "scripts/compilation/fake-compile.sh", size: 6, mode: os.FileMode(420), modTime: time.Unix(1444232057, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }
@@ -106,7 +106,7 @@ func scriptsCompilationFakePrerequisitesSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "scripts/compilation/fake-prerequisites.sh", size: 6, mode: os.FileMode(436), modTime: time.Unix(1443218238, 0)}
+	info := bindataFileInfo{name: "scripts/compilation/fake-prerequisites.sh", size: 6, mode: os.FileMode(420), modTime: time.Unix(1444232057, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }
@@ -126,7 +126,7 @@ func scriptsCompilationUbuntuCompileSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "scripts/compilation/ubuntu-compile.sh", size: 674, mode: os.FileMode(436), modTime: time.Unix(1443218238, 0)}
+	info := bindataFileInfo{name: "scripts/compilation/ubuntu-compile.sh", size: 674, mode: os.FileMode(420), modTime: time.Unix(1444232057, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }
@@ -146,7 +146,7 @@ func scriptsCompilationUbuntuPrerequisitesSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "scripts/compilation/ubuntu-prerequisites.sh", size: 1269, mode: os.FileMode(436), modTime: time.Unix(1444144646, 0)}
+	info := bindataFileInfo{name: "scripts/compilation/ubuntu-prerequisites.sh", size: 1269, mode: os.FileMode(420), modTime: time.Unix(1444232057, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }

--- a/scripts/templates/transformations.go
+++ b/scripts/templates/transformations.go
@@ -84,7 +84,7 @@ func scriptsTemplatesTransformationsYml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "scripts/templates/transformations.yml", size: 797, mode: os.FileMode(436), modTime: time.Unix(1444058541, 0)}
+	info := bindataFileInfo{name: "scripts/templates/transformations.yml", size: 797, mode: os.FileMode(420), modTime: time.Unix(1444232057, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }
@@ -104,7 +104,7 @@ func scriptsTemplatesTransformations_codeYml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "scripts/templates/transformations_code.yml", size: 193, mode: os.FileMode(436), modTime: time.Unix(1444058541, 0)}
+	info := bindataFileInfo{name: "scripts/templates/transformations_code.yml", size: 193, mode: os.FileMode(420), modTime: time.Unix(1444232057, 0)}
 	a := &asset{bytes: bytes, info:  info}
 	return a, nil
 }

--- a/util/tempdir.go
+++ b/util/tempdir.go
@@ -1,0 +1,11 @@
+// +build windows unix !darwin
+
+package util
+
+import "io/ioutil"
+
+// TempDir overrides the default TempDir, since Docker needs this
+// to be in your user folder.
+func TempDir(dir, prefix string) (name string, err error) {
+	return ioutil.TempDir(dir, prefix)
+}

--- a/util/tempdir_darwin.go
+++ b/util/tempdir_darwin.go
@@ -1,0 +1,45 @@
+package util
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+)
+
+// TempDir overrides the default TempDir, since Docker needs this
+// to be in your user folder. If this isn't in your user folder, then
+// docker cannot attach to the volume, and you get odd errors back
+// from docker.
+func TempDir(dir, prefix string) (name string, err error) {
+	homeDir := os.Getenv("HOME")
+
+	var fullPath string
+
+	if dir != "" {
+		fullPath = path.Join(homeDir, "tmp", dir)
+	} else {
+		fullPath = path.Join(homeDir, "tmp")
+	}
+
+	if pathExists, err := exists(fullPath); err != nil || !pathExists {
+		err := os.MkdirAll(fullPath, 0777)
+
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return ioutil.TempDir(fullPath, prefix)
+}
+
+// exists returns whether the given file or directory exists or not
+func exists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, err
+}


### PR DESCRIPTION
- Use the Docker environment variables to locate dockerd, as opposed to
  a hardcoded unix socket.
- Create a custom TempDir function that creates the tempdir under
  /Users/foo/tmp instead of the TMPDIR environment variable. This is
  necessary because Docker on a Mac can only mount volumes if the source
  folder is within the user's home folder. On all other platforms, this
  defers to the built-in ioutil.TempDir
