### PR TITLE
Add tasks (errands)

### DIFF
--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -63,10 +63,15 @@ func TestGenerateRoleImageRunScript(t *testing.T) {
 
 	runScriptContents, err := roleImageBuilder.generateRunScript(rolesManifest.Roles[0])
 	assert.Nil(err)
-
 	assert.Contains(string(runScriptContents), "/var/vcap/jobs-src/tor/templates/data/properties.sh.erb")
 	assert.Contains(string(runScriptContents), "/opt/hcf/monitrc.erb")
 	assert.Contains(string(runScriptContents), "/opt/hcf/startup/myrole.sh")
+	assert.Contains(string(runScriptContents), "monit -vI")
+
+	runScriptContents, err = roleImageBuilder.generateRunScript(rolesManifest.Roles[1])
+	assert.Nil(err)
+	assert.NotContains(string(runScriptContents), "monit -vI")
+	assert.Contains(string(runScriptContents), "/var/vcap/jobs/tor/bin/run")
 }
 
 func TestGenerateRoleImageDockerfileDir(t *testing.T) {

--- a/model/roles.go
+++ b/model/roles.go
@@ -18,6 +18,7 @@ type Role struct {
 	Name        string     `yaml:"name"`
 	Jobs        []*Job     `yaml:"_,omitempty"`
 	Scripts     []string   `yaml:"scripts"`
+	IsTask      bool       `yaml:"is_task,omitempty"`
 	JobNameList []*roleJob `yaml:"jobs"`
 
 	rolesManifest *RoleManifest

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -25,11 +25,18 @@ func TestLoadRoleManifestOK(t *testing.T) {
 
 	assert.Equal(roleManifestPath, rolesManifest.manifestFilePath)
 	assert.Equal(2, len(rolesManifest.Roles))
-	assert.Equal("tor", rolesManifest.Roles[1].Jobs[0].Name)
-	assert.NotNil(rolesManifest.Roles[1].Jobs[0].Release)
-	assert.Equal("tor", rolesManifest.Roles[1].Jobs[0].Release.Name)
-	assert.Equal(1, len(rolesManifest.Roles[0].Scripts))
-	assert.Equal("myrole.sh", rolesManifest.Roles[0].Scripts[0])
+
+	myrole := rolesManifest.Roles[0]
+	assert.False(myrole.IsTask)
+	assert.Equal(1, len(myrole.Scripts))
+	assert.Equal("myrole.sh", myrole.Scripts[0])
+
+	foorole := rolesManifest.Roles[1]
+	assert.True(foorole.IsTask)
+	torjob := foorole.Jobs[0]
+	assert.Equal("tor", torjob.Name)
+	assert.NotNil(torjob.Release)
+	assert.Equal("tor", torjob.Release.Name)
 }
 
 func TestGetScriptPaths(t *testing.T) {

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -94,4 +94,12 @@ bash /opt/hcf/startup/{{ $script }}
 {{ end }}
 
 # Run
+{{ with $role := index . "role" }}
+{{ if .IsTask }}
+{{ range $i, $job := .Jobs}}
+/var/vcap/jobs/{{ $job.Name }}/bin/run
+{{ end }}
+{{ else }}
 monit -vI
+{{ end }}
+{{ end }}

--- a/test-assets/role-manifests/tor-good.yml
+++ b/test-assets/role-manifests/tor-good.yml
@@ -1,11 +1,11 @@
 ---
 roles:
-  - name: myrole
-    scripts: ["myrole.sh"]
-    jobs:
-      - name: new_hostname
-      - name: tor
-  - name: foorole
-    jobs:
-      - name: tor
- 
+- name: myrole
+  scripts: ["myrole.sh"]
+  jobs:
+  - name: new_hostname
+  - name: tor
+- name: foorole
+  is_task: true
+  jobs:
+  - name: tor


### PR DESCRIPTION
This will allow us to run short-lived containers for what bosh calls errands. We are calling them tasks. Will make it possible to run the acceptance and smoke test containers.
