### PR TITLE
Add a helpful comment (and remove a wayward tab).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ bindata:
 	go-bindata -pkg=dockerfiles -o=./scripts/dockerfiles/dockerfiles.go ./scripts/dockerfiles/Dockerfile-* ./scripts/dockerfiles/monitrc.erb ./scripts/dockerfiles/*.sh &&\
 	go-bindata -pkg=templates -o=./scripts/templates/transformations.go ./scripts/templates/*.yml
 	@echo "$(NO_COLOR)\c"
-	
+
 build: bindata
 	@echo "$(OK_COLOR)==> Building$(NO_COLOR)"
 	export GOPATH=$(shell godep path):$(shell echo $$GOPATH) &&\
@@ -61,6 +61,7 @@ tools:
 	go get -u github.com/mitchellh/gox
 	@echo "$(NO_COLOR)\c"
 
+# If this fails, try running 'make bindata' and rerun 'make test'
 test:
 	@echo "$(OK_COLOR)==> Testing$(NO_COLOR)"
 	export GOPATH=$(shell godep path):$(shell echo $$GOPATH) &&\


### PR DESCRIPTION
It's possible to make 'test' dependent on 'bindata', but that would
require adding correct dependencies for the bindata rule.
