### PR TITLE
HCF-333: Do not attempt to build if there are no packages to build.

### DIFF
--- a/compilator/compilator.go
+++ b/compilator/compilator.go
@@ -98,6 +98,10 @@ func (c *Compilator) Compile(workerCount int, release *model.Release) error {
 	if err != nil {
 		return fmt.Errorf("failed to remove compiled packages: %v", err)
 	}
+	if 0 == len(packages) {
+		log.Println("No package needed to be built")
+		return nil
+	}
 
 	todoCh := make(chan *model.Package)
 	doneCh := make(chan compileResult)

--- a/compilator/compilator_test.go
+++ b/compilator/compilator_test.go
@@ -38,6 +38,22 @@ func TestMain(m *testing.M) {
 	os.Exit(retCode)
 }
 
+func TestCompilationEmpty(t *testing.T) {
+	assert := assert.New(t)
+
+	c, err := NewCompilator(nil, "", "", "", "")
+	assert.Nil(err)
+
+	waitCh := make(chan struct{})
+	go func() {
+		err := c.Compile(1, genTestCase())
+		close(waitCh)
+		assert.Nil(err)
+	}()
+
+	<-waitCh
+}
+
 func TestCompilationBasic(t *testing.T) {
 	saveCompilePackage := compilePackageHarness
 	defer func() {


### PR DESCRIPTION
Otherwise scheduleWork() will die in createDepBuckets() because it tries
to access the first element of an empty array.
