### PR TITLE
HCF-315 There is only one SHA1sum of license.tgz, not the license files

### DIFF
--- a/builder/role_image.go
+++ b/builder/role_image.go
@@ -61,16 +61,10 @@ func (r *RoleImageBuilder) CreateDockerfileDir(role *model.Role) (string, error)
 	}
 
 	// Write out license files
-	if license := &role.Jobs[0].Release.License; license.Contents != nil {
-		err := ioutil.WriteFile(filepath.Join(roleDir, license.Filename), license.Contents, 0644)
+	for filename, contents := range role.Jobs[0].Release.License.Files {
+		err := ioutil.WriteFile(filepath.Join(roleDir, filename), contents, 0644)
 		if err != nil {
-			return "", fmt.Errorf("failed to write out license file: %v", err)
-		}
-	}
-	if notice := role.Jobs[0].Release.Notice; notice.Contents != nil {
-		err := ioutil.WriteFile(filepath.Join(roleDir, notice.Filename), notice.Contents, 0644)
-		if err != nil {
-			return "", fmt.Errorf("failed to write out notice file: %v", err)
+			return "", fmt.Errorf("failed to write out license file %s: %v", filename, err)
 		}
 	}
 
@@ -228,8 +222,7 @@ func (r *RoleImageBuilder) generateDockerfile(role *model.Role) ([]byte, error) 
 		"base_image":    baseImage,
 		"image_version": r.version,
 		"role":          role,
-		"license":       role.Jobs[0].Release.License.Filename,
-		"notice":        role.Jobs[0].Release.Notice.Filename,
+		"licenses":      role.Jobs[0].Release.License.Files,
 	}
 
 	dockerfileTemplate, err = dockerfileTemplate.Parse(string(asset))

--- a/model/models.go
+++ b/model/models.go
@@ -2,10 +2,14 @@ package model
 
 // ReleaseLicense represents the license of a BOSH release
 type ReleaseLicense struct {
-	Filename string
-	SHA1     string
-	Contents []byte
-	Release  *Release
+	// ActualSHA1 is the SHA1 of the archive we actually have
+	ActualSHA1 string
+	// SHA1 is the SHA1 of the archive as specified in the manifest
+	SHA1       string
+	// Files is a mapping of license file names to contents
+	Files      map[string][]byte
+	// Release this license belongs to
+	Release    *Release
 }
 
 // JobProperty is a generic key-value property referenced by a job

--- a/model/release_test.go
+++ b/model/release_test.go
@@ -222,9 +222,9 @@ func TestReleaseLicenseOk(t *testing.T) {
 	err = release.loadLicense()
 
 	assert.Nil(err)
-	assert.NotEmpty(release.License.Contents)
-	assert.Equal(40, len(release.License.SHA1))
-	assert.Equal("LICENSE", release.License.Filename)
+	assert.Equal(40, len(release.License.ActualSHA1))
+	assert.NotEmpty(release.License.Files)
+	assert.NotNil(release.License.Files["LICENSE"])
 }
 
 func TestReleaseLicenseNotOk(t *testing.T) {
@@ -243,8 +243,7 @@ func TestReleaseLicenseNotOk(t *testing.T) {
 	if assert.NotNil(err) {
 		assert.Contains(err.Error(), "unexpected EOF")
 	}
-	assert.Nil(release.License.Contents)
-	assert.Empty(release.License.SHA1)
+	assert.Empty(release.License.Files)
 }
 
 func TestGetDeploymentConfig(t *testing.T) {

--- a/scripts/dockerfiles/Dockerfile-role
+++ b/scripts/dockerfiles/Dockerfile-role
@@ -31,8 +31,8 @@ ADD role-startup /opt/hcf/startup/
 ADD run.sh /opt/hcf/
 
 # Add license and/or notice file
-{{ if or (.license) (.notice) }}
-ADD {{.license}} {{.notice}} /opt/hcf/share/doc/
+{{ if gt (len .licenses) 0 }}
+ADD {{ range $name, $_ := .licenses }}{{$name}} {{end}} /opt/hcf/share/doc/
 {{ end }}
 
 ENTRYPOINT ["/bin/bash", "/opt/hcf/run.sh"]


### PR DESCRIPTION
As the SHA1 listed in the release manifest is for the whole `license.tgz` (and not for each file listed in there), how we keep track of the licenses needs to be adjusted.

This is in preparation of implementing `fissile release verify`, but can be landed first.
