### PR TITLE
Do not fail if taking ownership fails

### DIFF
--- a/scripts/compilation/ubuntu-compile.sh
+++ b/scripts/compilation/ubuntu-compile.sh
@@ -31,4 +31,4 @@ ln -s /fissile-out $BOSH_INSTALL_TARGET
 cd $BOSH_COMPILE_TARGET
 bash ./packaging
 
-chown -R ${HOST_USERID}:${HOST_USERGID} /fissile-out
+chown -R ${HOST_USERID}:${HOST_USERGID} /fissile-out 2>/dev/null || echo "Warning - could not change ownership of compiled artifacts" 1>&2


### PR DESCRIPTION
Taking ownership of the compiled artifacts can fail depending on the underlying filesystem. An example where this is the case is vmhgfs, where this command fails because the host of the VM may not have a user with the UID and GID that match the user that ran the commands in the guest.
In this case, vmhgfs actually does the UID and GID translation for us, so the chown would be superflous.
