### PR TITLE
HCF-425: update paths to cf docs for building opinion files

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ The following diagram shows the ordering of things. The highlighted items are co
 - `configuration generate`
 
  - `--release <RELEASE_PATH>` path to BOSH release(s) - you can specify this parameter multiple times **(not optional)**
- - `--light-opinions <LIGHT_OPINIONS_YAML_PATH>` path to a BOSH YAML deployment manifest generated using the instructions found [here](https://docs.cloudfoundry.org/deploying/common/create_a_manifest.html#generate-manifest) **(not optional)** (the stub file should be `.../hcf-infrastructure/config-opinions/cf-openstack-stub.yml`)
- - `--dark-opinions <DARK_OPINIONS_YAML_PATH>`. Normally, the path should point to an edited version of the `cf-stub` BOSH YAML deployment manifest as documented [here](https://docs.cloudfoundry.org/deploying/openstack/cf-stub.html) **(not optional)**. The file `.../hcf-infrastructure/config-opinions/cf-openstack-stub.yml` should be suitable as is.
+ - `--light-opinions <LIGHT_OPINIONS_YAML_PATH>` path to a BOSH YAML deployment manifest generated using the instructions found [here](https://docs.cloudfoundry.org/deploying/common/create_a_manifest.html#generate-manifest) **(not optional)** 
+ - `--dark-opinions <DARK_OPINIONS_YAML_PATH>`. Normally, the path should point to an edited version of the `cf-stub` BOSH YAML deployment manifest as documented [here](https://docs.cloudfoundry.org/deploying/openstack/cf-stub.html) **(not optional)**.
  - `--target <TARGET_DIRECTORY>` path to a directory where the command will write the configuration **(not optional)**
  - `--prefix <CONFIGURATION_KEYS_PREFIX>` a prefix to be used for all the BOSH keys; defaults to `hcf`
  - `--provider <GENERATION_PROVIDER>` the provider to use when generating the configuration; defaults to `dirtree` (this is the only provider currently available)


### PR DESCRIPTION
The cf docs were reorganized and the links for --light-opinions and --dark-opinions broke.  Plus, the instructions were never explicit on which cf-stub.yml file to use.  I'm proposing that we maintain our own template in hcf-infrastructure (to be done in HCF-381).
