### PR TITLE
Add role jobs to configgin input data in run.sh

### DIFF
--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -97,6 +97,7 @@ func TestGenerateRoleImageRunScript(t *testing.T) {
 	assert.Contains(string(runScriptContents), "/opt/hcf/monitrc.erb")
 	assert.Contains(string(runScriptContents), "/opt/hcf/startup/myrole.sh")
 	assert.Contains(string(runScriptContents), "monit -vI")
+	assert.Contains(string(runScriptContents), "\"templates\":[{\"name\":\"new_hostname\"},{\"name\":\"tor\"}]")
 
 	runScriptContents, err = roleImageBuilder.generateRunScript(rolesManifest.Roles[1])
 	assert.Nil(err)

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -38,7 +38,7 @@ ip_address=`/bin/hostname -i`
 # ============================================================================
 {{ range $j, $template := $job.Templates }}
 /opt/hcf/configgin/configgin \
-  --data '{"job": { "name": "{{ $role.Name }}" }, "index": '"${role_instance_index}"', "parameters": {}, "networks": { "default":{ "ip":"'"${ip_address}"'", "dns_record_name":"'"${dns_record_name}"'"}}}' \
+  --data '{"job": { "name": "{{ $role.Name }}" }, "index": '"${role_instance_index}"', "parameters": {}, "networks": { "default":{ "ip":"'"${ip_address}"'", "dns_record_name":"'"${dns_record_name}"'"}}, "templates":[{{ range $iJob, $innerJob := $role.Jobs}}{{if $iJob}},{{end}}{"name":"{{$innerJob.Name}}"}{{ end }}]}' \
   --output  "/var/vcap/jobs/{{ $job.Name }}/{{$template.DestinationPath}}" \
   --consul  "${consul_address}" \
   --prefix  "${config_store_prefix}" \
@@ -53,7 +53,7 @@ ip_address=`/bin/hostname -i`
 #         Templates for job {{ $job.Name }}
 # ============================================================================
 /opt/hcf/configgin/configgin \
-  --data '{"job": { "name": "{{ $role.Name }}" }, "index": '"${role_instance_index}"', "parameters": {}, "networks": { "default":{ "ip":"'"${ip_address}"'", "dns_record_name":"'"${dns_record_name}"'"}}}' \
+  --data '{"job": { "name": "{{ $role.Name }}" }, "index": '"${role_instance_index}"', "parameters": {}, "networks": { "default":{ "ip":"'"${ip_address}"'", "dns_record_name":"'"${dns_record_name}"'"}}, "templates":[{{ range $iJob, $innerJob := $role.Jobs}}{{if $iJob}},{{end}}{"name":"{{$innerJob.Name}}"}{{ end }}]}' \
   --output  "/var/vcap/monit/{{ $job.Name }}.monitrc" \
   --consul  "${consul_address}" \
   --prefix  "${config_store_prefix}" \
@@ -68,7 +68,7 @@ ip_address=`/bin/hostname -i`
 {{ if not .IsTask }}
 # Process monitrc.erb template
 /opt/hcf/configgin/configgin \
-  --data '{"job": { "name": "{{ $role.Name }}" }, "index": '"${role_instance_index}"', "parameters": {}, "networks": { "default":{ "ip":"'"${ip_address}"'", "dns_record_name":"'"${dns_record_name}"'"}}}' \
+  --data '{"job": { "name": "{{ $role.Name }}" }, "index": '"${role_instance_index}"', "parameters": {}, "networks": { "default":{ "ip":"'"${ip_address}"'", "dns_record_name":"'"${dns_record_name}"'"}}, "templates":[{{ range $iJob, $innerJob := $role.Jobs}}{{if $iJob}},{{end}}{"name":"{{$innerJob.Name}}"}{{ end }}]}' \
   --output  "/etc/monitrc" \
   --consul  "${consul_address}" \
   --prefix  "${config_store_prefix}" \


### PR DESCRIPTION
Some Diego templates require iteration through all the jobs of a role.
This translates to an array of "templates" in the spec[] object in the evaluation context of a BOSH template.
