### PR TITLE
HCF-430 Fix location of templates in configgin data.

### DIFF
--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -38,7 +38,7 @@ ip_address=`/bin/hostname -i`
 # ============================================================================
 {{ range $j, $template := $job.Templates }}
 /opt/hcf/configgin/configgin \
-  --data '{"job": { "name": "{{ $role.Name }}" }, "index": '"${role_instance_index}"', "parameters": {}, "networks": { "default":{ "ip":"'"${ip_address}"'", "dns_record_name":"'"${dns_record_name}"'"}, "templates":[{{ range $iJob, $innerJob := $role.Jobs}}{{if $iJob}},{{end}}{"name":"{{$innerJob.Name}}"}{{ end }}]}}' \
+  --data '{"job": { "name": "{{ $role.Name }}", "templates":[{{ range $iJob, $innerJob := $role.Jobs}}{{if $iJob}},{{end}}{"name":"{{$innerJob.Name}}"}{{ end }}] }, "index": '"${role_instance_index}"', "parameters": {}, "networks": { "default":{ "ip":"'"${ip_address}"'", "dns_record_name":"'"${dns_record_name}"'"}}}' \
   --output  "/var/vcap/jobs/{{ $job.Name }}/{{$template.DestinationPath}}" \
   --consul  "${consul_address}" \
   --prefix  "${config_store_prefix}" \
@@ -53,7 +53,7 @@ ip_address=`/bin/hostname -i`
 #         Templates for job {{ $job.Name }}
 # ============================================================================
 /opt/hcf/configgin/configgin \
-  --data '{"job": { "name": "{{ $role.Name }}" }, "index": '"${role_instance_index}"', "parameters": {}, "networks": { "default":{ "ip":"'"${ip_address}"'", "dns_record_name":"'"${dns_record_name}"'"}, "templates":[{{ range $iJob, $innerJob := $role.Jobs}}{{if $iJob}},{{end}}{"name":"{{$innerJob.Name}}"}{{ end }}]}}' \
+  --data '{"job": { "name": "{{ $role.Name }}", "templates":[{{ range $iJob, $innerJob := $role.Jobs}}{{if $iJob}},{{end}}{"name":"{{$innerJob.Name}}"}{{ end }}] }, "index": '"${role_instance_index}"', "parameters": {}, "networks": { "default":{ "ip":"'"${ip_address}"'", "dns_record_name":"'"${dns_record_name}"'"}}}' \
   --output  "/var/vcap/monit/{{ $job.Name }}.monitrc" \
   --consul  "${consul_address}" \
   --prefix  "${config_store_prefix}" \
@@ -68,7 +68,7 @@ ip_address=`/bin/hostname -i`
 {{ if not .IsTask }}
 # Process monitrc.erb template
 /opt/hcf/configgin/configgin \
-  --data '{"job": { "name": "{{ $role.Name }}" }, "index": '"${role_instance_index}"', "parameters": {}, "networks": { "default":{ "ip":"'"${ip_address}"'", "dns_record_name":"'"${dns_record_name}"'"}, "templates":[{{ range $iJob, $innerJob := $role.Jobs}}{{if $iJob}},{{end}}{"name":"{{$innerJob.Name}}"}{{ end }}]}}' \
+  --data '{"job": { "name": "{{ $role.Name }}", "templates":[{{ range $iJob, $innerJob := $role.Jobs}}{{if $iJob}},{{end}}{"name":"{{$innerJob.Name}}"}{{ end }}] }, "index": '"${role_instance_index}"', "parameters": {}, "networks": { "default":{ "ip":"'"${ip_address}"'", "dns_record_name":"'"${dns_record_name}"'"}}}' \
   --output  "/etc/monitrc" \
   --consul  "${consul_address}" \
   --prefix  "${config_store_prefix}" \


### PR DESCRIPTION
The templates key needs to be inside the value of the job key.
