### PR TITLE
HCF-469 - Don't use the docker command while testing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PKGSDIRS=$(shell go list -f '{{.Dir}}' ./... | sed /templates/d)
 
 print_status = @printf "\033[32;01m==> $(1)\033[0m\n"
 
-.PHONY: all clean format lint vet bindata build test docker-deps
+.PHONY: all clean format lint vet bindata build test docker-deps reap
 all: clean format lint vet bindata build test docker-deps
 
 clean:
@@ -65,7 +65,9 @@ tools:
 # If this fails, try running 'make bindata' and rerun 'make test'
 test:
 	$(call print_status, Testing)
-	# Remove exited test containers
-	docker ps -a --filter=status=exited | awk '/fissile-test-/ {print $$1}' | xargs --no-run-if-empty docker rm
 	export GOPATH=$(shell godep path):$(GOPATH) &&\
 		go test -cover ./...
+
+reap:
+	# Remove exited test containers
+	docker ps -a --filter=status=exited | awk '/fissile-test-/ {print $$1}' | xargs --no-run-if-empty docker rm


### PR DESCRIPTION
Reap exited containers later.
