### PR TITLE
Error logs not being output when colorizing

### DIFF
--- a/compilator/compilator.go
+++ b/compilator/compilator.go
@@ -367,13 +367,13 @@ func (c *Compilator) compilePackage(pkg *model.Package) (err error) {
 	stdoutWriter := docker.NewFormattingWriter(
 		log,
 		func(line string) string {
-			return color.GreenString("compilation-%s > %s", color.MagentaString(pkg.Name), color.WhiteString("%s", line))
+			return color.GreenString("compilation-%s > %s", color.MagentaString("%s", pkg.Name), color.WhiteString("%s", line))
 		},
 	)
 	stderrWriter := docker.NewFormattingWriter(
 		log,
 		func(line string) string {
-			return color.GreenString("compilation-%s > %s", color.MagentaString(pkg.Name), color.RedString("%s", line))
+			return color.GreenString("compilation-%s > %s", color.MagentaString("%s", pkg.Name), color.RedString("%s", line))
 		},
 	)
 	exitCode, container, err := c.DockerManager.RunInContainer(


### PR DESCRIPTION
`io.Writer`'s `Write()` needs to return the number of bytes of the input buffer that was consumed, not the number of (munged) bytes that was output.  Otherwise the caller assumes that the output had reached EOF and stops emitting.

Found this when using libvirt vagrant box, since code tried to do a `cp -a` and was failing with permission issues due to the nfs mount.  That will need to be looked at later.
