### PR TITLE
HCF-428 Fix container name sanitization

### DIFF
--- a/compilator/compilator.go
+++ b/compilator/compilator.go
@@ -552,7 +552,7 @@ func (c *Compilator) getPackageContainerName(pkg *model.Package) string {
 
 // BaseCompilationImageTag will return the compilation image tag
 func (c *Compilator) baseCompilationImageTag() string {
-	return fmt.Sprintf("%s", c.FissileVersion)
+	return util.SanitizeDockerName(fmt.Sprintf("%s", c.FissileVersion))
 }
 
 // baseCompilationImageRepository will return the compilation image repository


### PR DESCRIPTION
We fixed the image (tag) name, but not the container name.

This is an extension of #97
