### PR TITLE
Compilator: Add ability to only compile some packages

### DIFF
--- a/app/command_router.go
+++ b/app/command_router.go
@@ -159,7 +159,9 @@ func (f *Fissile) CommandRouter(c *cli.Context) {
 			paths["cache-dir"],
 			c.String("repository"),
 			paths["compilation-dir"],
+			c.StringSlice("package-filter"),
 			c.Int("workers"),
+			c.Bool("debug"),
 		)
 	case "dev create-images":
 		if err = validateDevReleaseArgs(c); err != nil {

--- a/app/fissile.go
+++ b/app/fissile.go
@@ -367,7 +367,7 @@ func (f *Fissile) Compile(releasePath, repository, targetPath string, workerCoun
 		return fmt.Errorf("Error creating a new compilator: %s", err.Error())
 	}
 
-	if err := comp.Compile(workerCount, release); err != nil {
+	if err := comp.Compile(workerCount, release, nil); err != nil {
 		return fmt.Errorf("Error compiling packages: %s", err.Error())
 	}
 

--- a/app/fissile_dev.go
+++ b/app/fissile_dev.go
@@ -66,7 +66,7 @@ func (f *Fissile) ListDevJobs(releasePaths, releaseNames, releaseVersions []stri
 }
 
 // CompileDev will compile a list of dev BOSH releases
-func (f *Fissile) CompileDev(releasePaths, releaseNames, releaseVersions []string, cacheDir, repository, targetPath string, workerCount int) error {
+func (f *Fissile) CompileDev(releasePaths, releaseNames, releaseVersions []string, cacheDir, repository, targetPath string, packageFilter []string, workerCount int, keepContainer bool) error {
 	dockerManager, err := docker.NewImageManager()
 	if err != nil {
 		return fmt.Errorf("Error connecting to docker: %s", err.Error())
@@ -80,12 +80,12 @@ func (f *Fissile) CompileDev(releasePaths, releaseNames, releaseVersions []strin
 	for _, release := range releases {
 		f.ui.Println(color.GreenString("Compiling packages for dev release %s (%s) ...", color.YellowString(release.Name), color.MagentaString(release.Version)))
 
-		comp, err := compilator.NewCompilator(dockerManager, targetPath, repository, compilation.UbuntuBase, f.Version, false, f.ui)
+		comp, err := compilator.NewCompilator(dockerManager, targetPath, repository, compilation.UbuntuBase, f.Version, keepContainer, f.ui)
 		if err != nil {
 			return fmt.Errorf("Error creating a new compilator: %s", err.Error())
 		}
 
-		if err := comp.Compile(workerCount, release); err != nil {
+		if err := comp.Compile(workerCount, release, packageFilter); err != nil {
 			return fmt.Errorf("Error compiling packages: %s", err.Error())
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -95,6 +95,11 @@ func main() {
 		Usage:  "If specified, containers won't be deleted when their build fails.",
 		EnvVar: "FISSILE_DEBUG",
 	}
+	packageFilterFlag := cli.StringSliceFlag{
+		Name:   "package-filter",
+		Usage:  "Compile only the selected packages",
+		EnvVar: "FISSILE_PACKAGE_FILTER",
+	}
 
 	workdirFlag := cli.StringFlag{
 		Name:   "work-dir, wd",
@@ -383,7 +388,9 @@ func main() {
 						cacheDirFlag,
 						workdirFlag,
 						repositoryFlag,
+						packageFilterFlag,
 						workersFlag,
+						debugFlag,
 					},
 					Usage:  "Compiles packages from dev releases using parallel workers",
 					Action: fissile.CommandRouter,


### PR DESCRIPTION
Useful when using along with `--debug` to limit the containers to look at.
