### PR TITLE
HCF-548 Don't use the network during the test

### DIFF
--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -133,6 +133,7 @@ func TestRunInContainerWithInFiles(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	stdoutWriter := NewFormattingWriter(buf, nil)
+	stderrWriter := new(bytes.Buffer)
 
 	exitCode, container, err := dockerManager.RunInContainer(
 		getTestName(),
@@ -142,7 +143,7 @@ func TestRunInContainerWithInFiles(t *testing.T) {
 		"",
 		false,
 		stdoutWriter,
-		nil,
+		stderrWriter,
 	)
 
 	if !assert.NoError(err) {
@@ -150,6 +151,7 @@ func TestRunInContainerWithInFiles(t *testing.T) {
 	}
 	assert.Equal(0, exitCode)
 	assert.NotEmpty(buf)
+	assert.Empty(strings.TrimSpace(stderrWriter.String()))
 
 	err = dockerManager.RemoveContainer(container.ID)
 	assert.NoError(err)


### PR DESCRIPTION
There's some issues with the fissile tests on concourse.

This includes the fix (don't touch the network), in addition to some changes to make future debugging easier.  The CI should pass before we merge, obviously.
