### PR TITLE
Don't install go vet

### DIFF
--- a/make/tools
+++ b/make/tools
@@ -2,7 +2,6 @@
 
 set -o errexit
 
-go get -u golang.org/x/tools/cmd/vet
 go get -u golang.org/x/tools/cmd/goimports
 go get -u github.com/golang/lint/golint
 go get -u github.com/AlekSi/gocov-xml


### PR DESCRIPTION
It seems the vet package doesn't exist anymore as it is now included in go. This causes an error on `make tools`
