### PR TITLE
Fix a typo in docker name sanitization

### DIFF
--- a/util/name_sanitization.go
+++ b/util/name_sanitization.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	rgxDockerNames = regexp.MustCompile(`(?i)[^a-z0-9_.-:]+`)
+	rgxDockerNames = regexp.MustCompile(`(?i)[^a-z0-9_.:-]+`)
 )
 
 // SanitizeDockerName makes a string conform with the rules for Docker names

--- a/util/name_sanitization_test.go
+++ b/util/name_sanitization_test.go
@@ -1,0 +1,21 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeDockerName(t *testing.T) {
+	assert := assert.New(t)
+
+	for input, output := range map[string]string{
+		"semver+build":  "semver-build",
+		"branch-name":   "branch-name",
+		"remote/branch": "remote-branch",
+		"image:tag":     "image:tag",
+		"[Ｇｏ]\n":        "-",
+	} {
+		assert.Equal(output, SanitizeDockerName(input), "Incorrect sanitization")
+	}
+}


### PR DESCRIPTION
We should not include / in the set of things we allow; we previously had a range where we meant three specific characters.

Also adds tests, because… tests.
