### PR TITLE
HCF-622: Add vcap user to compilation base image

### DIFF
--- a/scripts/compilation/ubuntu-prerequisites.sh
+++ b/scripts/compilation/ubuntu-prerequisites.sh
@@ -27,3 +27,6 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install -o Dpkg::Options::="--force-confnew" -f -y --force-yes --no-install-recommends $debs
+
+# Add the vcap:vcap user to match CF
+useradd -m --comment 'hcf user' vcap


### PR DESCRIPTION
This is required because the etcd-release testconsumer package assumes it exists.
