### PR TITLE
HCF-624 Remove old *.pid files on startup

### DIFF
--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -8,6 +8,12 @@ EOL
 exit 0
 fi
 
+# When the container gets restarted, processes may end up with different pids
+find /run -name "*.pid" -delete
+if [ -d /var/vcap/sys/run ]; then
+    find /var/vcap/sys/run -name "*.pid" -delete
+fi
+
 export IP_ADDRESS=$(/bin/hostname -i | awk '{print $1}')
 export DNS_RECORD_NAME=$(/bin/hostname)
 


### PR DESCRIPTION
If a container is restarted (docker restart, or vagrant box reboot),
then the processes might start in a different order and end up with
different pids.  And if e.g. monit sees that the process listed in
/run/monit.pid already exists, then it just "awakens" that daemon
and doesn't realize that it might be rsyslogd and not monit running.
