### PR TITLE
HCF-657 Stop sourcing make/* sub-scripts unnecessarily

### DIFF
--- a/make/bindata
+++ b/make/bindata
@@ -27,12 +27,3 @@ go-bindata -pkg=compilation -o=./scripts/compilation/compilation.go \
     -prefix ./test-assets \
     ./scripts/compilation \
     ./test-assets/scripts/compilation/*.sh
-
-exit
-
-# This is the code to use when go-bindata's issue #110 gets fixed.
-
-go-bindata -pkg=compilation -o=./scripts/compilation/compilation.go \
-    -prefix ./test-assets \
-    ./scripts/compilation/*.sh \
-    ./test-assets/scripts/compilation/*.sh

--- a/make/build
+++ b/make/build
@@ -6,7 +6,6 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
 set +o errexit
 
-. ${GIT_ROOT}/make/bindata
 . ${GIT_ROOT}/make/include/versioning
 
 set -o errexit
@@ -15,4 +14,5 @@ export GOPATH=$(godep path):${GOPATH}
 
 set -o nounset
 
+${GIT_ROOT}/make/bindata
 go build -ldflags="-X main.version=${APP_VERSION}"

--- a/make/package
+++ b/make/package
@@ -2,7 +2,6 @@
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
-. ${GIT_ROOT}/make/build
 . ${GIT_ROOT}/make/include/versioning
 
 set -o errexit -o nounset
@@ -10,4 +9,5 @@ set -o errexit -o nounset
 GOOS=${GOOS:-$(go env GOOS)}
 GOARCH=${GOARCH:-$(go env GOARCH)}
 
+${GIT_ROOT}/make/build
 tar czf ${APP_VERSION}-${GOOS}.${GOARCH}.tgz fissile


### PR DESCRIPTION
We don't want things inside the sub-scripts to affect the parent script.
Triggered via `make/bindata` trying to `exit` causing `make/build` to not actually build anything.
