### PR TITLE
HCF-658 Do not let fissile do anything if its version string is missing

### DIFF
--- a/main.go
+++ b/main.go
@@ -299,6 +299,11 @@ func main() {
 
 	cliApp.After = fissile.CommandAfterHandler
 
+	if cliApp.Version == "" {
+		ui.Println(color.RedString("Fissile was built incorrectly and its version string is missing"))
+		sigint.DefaultHandler.Exit(1)
+	}
+
 	if err := cliApp.Run(os.Args); err != nil {
 		ui.Println(color.RedString("%v", err))
 		sigint.DefaultHandler.Exit(1)


### PR DESCRIPTION
We use it for the docker tag name for the compilation base image and things along those lines.  If it's missing the binary cannot do anything useful.
