### PR TITLE
Add PSP support

### DIFF
--- a/app/fissile_test.go
+++ b/app/fissile_test.go
@@ -404,6 +404,23 @@ func TestGenerateAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	samples := map[string][]string{
+		`auth/auth-clusterrole-nonprivileged.yaml`: []string{
+			`{
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+				"kind": "ClusterRole",
+				"metadata": {
+					"name": "psp-role-nonprivileged"
+				},
+				"rules": [
+					{
+						"apiGroups": ["extensions"],
+						"resourceNames": ["nonprivileged"],
+						"resources": ["podsecuritypolicies"],
+						"verbs": ["use"]
+					}
+				]
+			}`,
+		},
 		`auth/auth-role-extra-permissions.yaml`: []string{
 			`{
 				"apiVersion": "rbac.authorization.k8s.io/v1beta1",

--- a/app/fissile_test.go
+++ b/app/fissile_test.go
@@ -462,6 +462,25 @@ func TestGenerateAuth(t *testing.T) {
 					"apiGroup": "rbac.authorization.k8s.io"
 				}
 			}`,
+			`{
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+				"kind": "ClusterRoleBinding",
+				"metadata": {
+					"name": "non-default-binding-psp"
+				},
+				"subjects": [
+					{
+						"kind": "ServiceAccount",
+						"name": "non-default",
+						"namespace": "~"
+					}
+				],
+				"roleRef": {
+					"kind": "ClusterRole",
+					"name": "psp-role-nonprivileged",
+					"apiGroup": "rbac.authorization.k8s.io"
+				}
+			}`,
 		},
 		`auth/account-default.yaml`: []string{
 			// Service accounts named "default" should not get created
@@ -480,6 +499,25 @@ func TestGenerateAuth(t *testing.T) {
 				"roleRef": {
 					"kind": "Role",
 					"name": "pointless",
+					"apiGroup": "rbac.authorization.k8s.io"
+				}
+			}`,
+			`{
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+				"kind": "ClusterRoleBinding",
+				"metadata": {
+					"name": "default-binding-psp"
+				},
+				"subjects": [
+					{
+						"kind": "ServiceAccount",
+						"name": "default",
+						"namespace": "~"
+					}
+				],
+				"roleRef": {
+					"kind": "ClusterRole",
+					"name": "psp-role-nonprivileged",
 					"apiGroup": "rbac.authorization.k8s.io"
 				}
 			}`,

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -53,11 +53,6 @@ func NewPodTemplate(role *model.InstanceGroup, settings ExportSettings, grapher 
 		spec.Add("serviceAccountName", role.Run.ServiceAccount, block)
 	}
 
-	// Note: This group's PSP reference is not used, as it is not
-	// relevant here anymore. The call to function
-	// `resolveSecurityPolicies` integrated them into the service
-	// accounts.
-
 	// BOSH can potentially have an infinite termination grace period; we don't
 	// really trust that, so we'll just go with ten minutes and hope it's enough
 	spec.Add("terminationGracePeriodSeconds", 600)

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -44,7 +44,7 @@ func NewPodTemplate(role *model.InstanceGroup, settings ExportSettings, grapher 
 	spec.Add("dnsPolicy", "ClusterFirst")
 	spec.Add("volumes", getNonClaimVolumes(role, settings.CreateHelmChart))
 	spec.Add("restartPolicy", "Always")
-	if role.Run.ServiceAccount != "" {
+	if role.Run.ServiceAccount != "default" {
 		// This role requires a custom service account
 		block := helm.Block("")
 		if settings.CreateHelmChart {
@@ -52,6 +52,12 @@ func NewPodTemplate(role *model.InstanceGroup, settings ExportSettings, grapher 
 		}
 		spec.Add("serviceAccountName", role.Run.ServiceAccount, block)
 	}
+
+	// Note: This group's PSP reference is not used, as it is not
+	// relevant here anymore. The call to function
+	// `resolveSecurityPolicies` integrated them into the service
+	// accounts.
+
 	// BOSH can potentially have an infinite termination grace period; we don't
 	// really trust that, so we'll just go with ten minutes and hope it's enough
 	spec.Add("terminationGracePeriodSeconds", 600)

--- a/kube/rbac.go
+++ b/kube/rbac.go
@@ -48,7 +48,7 @@ func NewRBACAccount(name string, account model.AuthAccount, settings ExportSetti
 		// We have no proper namespace default for kube configuration.
 		namespace := "~"
 		if settings.CreateHelmChart {
-			blockPSP = authPSP(account.PodSecurityPolicy)
+			blockPSP = authPSPCondition(account.PodSecurityPolicy)
 			namespace = "{{ .Release.Namespace }}"
 		}
 
@@ -102,8 +102,8 @@ func NewRBACRole(name string, role model.AuthRole, settings ExportSettings) (hel
 	return container.Sort(), nil
 }
 
-// authPSP creates a block condition checking for RBAC and the named PSP
-func authPSP(psp string) helm.NodeModifier {
+// authPSPCondition creates a block condition checking for RBAC and the named PSP
+func authPSPCondition(psp string) helm.NodeModifier {
 	return helm.Block(fmt.Sprintf(`if and (%s) .Values.kube.psp.%s`,
 		`eq (printf "%s" .Values.kube.auth) "rbac"`, psp))
 }
@@ -121,7 +121,7 @@ func NewRBACClusterRolePSP(psp string, settings ExportSettings) (helm.Node, erro
 	container := newTypeMeta("rbac.authorization.k8s.io/v1", "ClusterRole")
 
 	if settings.CreateHelmChart {
-		container.Set(authPSP(psp))
+		container.Set(authPSPCondition(psp))
 		psp = fmt.Sprintf("{{ .Values.kube.psp.%s | quote }}", psp)
 	}
 

--- a/kube/rbac_test.go
+++ b/kube/rbac_test.go
@@ -57,13 +57,83 @@ func TestNewRBACAccountKube(t *testing.T) {
 	`, actualRole)
 }
 
-func TestNewRBACAccountHelmNoAuth(t *testing.T) {
+func TestNewRBACAccountPSPKube(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
 	resources, err := NewRBACAccount("the-name",
 		model.AuthAccount{
-			Roles: []string{"a-role"},
+			Roles:             []string{"a-role"},
+			PodSecurityPolicy: "privileged",
+		}, ExportSettings{})
+
+	if !assert.NoError(err) {
+		return
+	}
+	if !assert.Len(resources, 3, "Should have account, role and cluster role bindings") {
+		return
+	}
+
+	rbacAccount := resources[0]
+	actualAccount, err := RoundtripKube(rbacAccount)
+	if !assert.NoError(err) {
+		return
+	}
+	testhelpers.IsYAMLEqualString(assert, `---
+		apiVersion: "v1"
+		kind: "ServiceAccount"
+		metadata:
+			name: "the-name"
+	`, actualAccount)
+
+	rbacRole := resources[1]
+	actualRole, err := RoundtripKube(rbacRole)
+	if !assert.NoError(err) {
+		return
+	}
+	testhelpers.IsYAMLEqualString(assert, `---
+		apiVersion: "rbac.authorization.k8s.io/v1beta1"
+		kind: "RoleBinding"
+		metadata:
+			name: "the-name-a-role-binding"
+		subjects:
+		-	kind: "ServiceAccount"
+			name: "the-name"
+		roleRef:
+			kind: "Role"
+			name: "a-role"
+			apiGroup: "rbac.authorization.k8s.io"
+	`, actualRole)
+
+	pspBinding := resources[2]
+	actualBinding, err := RoundtripKube(pspBinding)
+	if !assert.NoError(err) {
+		return
+	}
+	testhelpers.IsYAMLEqualString(assert, `---
+		apiVersion: "rbac.authorization.k8s.io/v1"
+		kind: "ClusterRoleBinding"
+		metadata:
+			name: "the-name-binding-psp"
+		subjects:
+		-	kind: "ServiceAccount"
+			name: "the-name"
+			namespace: "~"
+		roleRef:
+			kind: "ClusterRole"
+			name: "psp-role-privileged"
+			apiGroup: "rbac.authorization.k8s.io"
+	`, actualBinding)
+}
+
+func TestNewRBACAccountHelm(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	resources, err := NewRBACAccount("the-name",
+		model.AuthAccount{
+			Roles:             []string{"a-role"},
+			PodSecurityPolicy: "nonprivileged",
 		}, ExportSettings{
 			CreateHelmChart: true,
 		})
@@ -71,12 +141,13 @@ func TestNewRBACAccountHelmNoAuth(t *testing.T) {
 	if !assert.NoError(err) {
 		return
 	}
-	if !assert.Len(resources, 2, "Should have account plus role") {
+	if !assert.Len(resources, 3, "Should have account plus role and cluster role bindings") {
 		return
 	}
 
 	rbacAccount := resources[0]
 	rbacRole := resources[1]
+	pspBinding := resources[2]
 
 	t.Run("NoAuth", func(t *testing.T) {
 		t.Parallel()
@@ -134,6 +205,73 @@ func TestNewRBACAccountHelmNoAuth(t *testing.T) {
 				name: "a-role"
 				apiGroup: "rbac.authorization.k8s.io"
 		`, actualRole)
+	})
+
+	t.Run("NoPodSecurityPolicy", func(t *testing.T) {
+		t.Parallel()
+		config := map[string]interface{}{
+			"Values.kube.auth": "rbac",
+		}
+		// config: .Values.kube.psp.nonprivileged: ~
+		actualAccount, err := RoundtripNode(rbacAccount, config)
+		if !assert.NoError(err) {
+			return
+		}
+		testhelpers.IsYAMLEqualString(assert, `---
+			apiVersion: "v1"
+			kind: "ServiceAccount"
+			metadata:
+				name: "the-name"
+		`, actualAccount)
+
+		// config: .Values.kube.psp.nonprivileged: ~
+		actualBinding, err := RoundtripNode(pspBinding, config)
+		if !assert.NoError(err) {
+			return
+		}
+
+		testhelpers.IsYAMLEqualString(assert, `---
+		`, actualBinding)
+	})
+
+	t.Run("HasPodSecurityPolicy", func(t *testing.T) {
+		t.Parallel()
+		config := map[string]interface{}{
+			"Values.kube.auth":              "rbac",
+			"Values.kube.psp.nonprivileged": "foo",
+			"Release.Namespace":             "a-namespace",
+		}
+
+		actualAccount, err := RoundtripNode(rbacAccount, config)
+		if !assert.NoError(err) {
+			return
+		}
+		testhelpers.IsYAMLEqualString(assert, `---
+			apiVersion: "v1"
+			kind: "ServiceAccount"
+			metadata:
+				name: "the-name"
+		`, actualAccount)
+
+		actualBinding, err := RoundtripNode(pspBinding, config)
+		if !assert.NoError(err) {
+			return
+		}
+
+		testhelpers.IsYAMLEqualString(assert, `---
+			apiVersion: "rbac.authorization.k8s.io/v1"
+			kind: "ClusterRoleBinding"
+			metadata:
+				name: "the-name-binding-psp"
+			subjects:
+			-	kind: "ServiceAccount"
+				name: "the-name"
+				namespace: "a-namespace"
+			roleRef:
+				kind: "ClusterRole"
+				name: "psp-role-nonprivileged"
+				apiGroup: "rbac.authorization.k8s.io"
+		`, actualBinding)
 	})
 }
 
@@ -234,4 +372,73 @@ func TestNewRBACRoleHelm(t *testing.T) {
 				-	"verb-iii"
 		`, actual)
 	})
+}
+
+func TestNewRBACClusterRolePSPKube(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	resource, err := NewRBACClusterRolePSP("the-name",
+		ExportSettings{})
+
+	if !assert.NoError(err) {
+		return
+	}
+
+	actualCR, err := RoundtripKube(resource)
+	if !assert.NoError(err) {
+		return
+	}
+	testhelpers.IsYAMLEqualString(assert, `---
+		apiVersion: "rbac.authorization.k8s.io/v1"
+		kind: "ClusterRole"
+		metadata:
+			name: "psp-role-the-name"
+		rules:
+		-	apiGroups:
+			-	"extensions"
+			resourceNames:
+			-	"the-name"
+			resources:
+			-	"podsecuritypolicies"
+			verbs:
+			-	"use"
+	`, actualCR)
+}
+
+func TestNewRBACClusterRolePSPHelm(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	resource, err := NewRBACClusterRolePSP("the_name",
+		ExportSettings{
+			CreateHelmChart: true,
+		})
+	if !assert.NoError(err) {
+		return
+	}
+
+	config := map[string]interface{}{
+		"Values.kube.auth":         "rbac",
+		"Values.kube.psp.the_name": "foo",
+	}
+	actualCR, err := RoundtripNode(resource, config)
+	if !assert.NoError(err) {
+		return
+	}
+	testhelpers.IsYAMLEqualString(assert, `---
+		apiVersion: "rbac.authorization.k8s.io/v1"
+		kind: "ClusterRole"
+		metadata:
+			name: "psp-role-the_name"
+		rules:
+		-	apiGroups:
+			-	"extensions"
+			resourceNames:
+			-	"foo"
+			resources:
+			-	"podsecuritypolicies"
+			verbs:
+			-	"use"
+	`, actualCR)
 }

--- a/kube/rbac_test.go
+++ b/kube/rbac_test.go
@@ -9,54 +9,6 @@ import (
 	"github.com/SUSE/fissile/testhelpers"
 )
 
-func TestNewRBACAccountKube(t *testing.T) {
-	t.Parallel()
-	assert := assert.New(t)
-
-	resources, err := NewRBACAccount("the-name",
-		model.AuthAccount{
-			Roles: []string{"a-role"},
-		}, ExportSettings{})
-
-	if !assert.NoError(err) {
-		return
-	}
-	if !assert.Len(resources, 2, "Should have account plus role") {
-		return
-	}
-
-	rbacAccount := resources[0]
-	actualAccount, err := RoundtripKube(rbacAccount)
-	if !assert.NoError(err) {
-		return
-	}
-	testhelpers.IsYAMLEqualString(assert, `---
-		apiVersion: "v1"
-		kind: "ServiceAccount"
-		metadata:
-			name: "the-name"
-	`, actualAccount)
-
-	rbacRole := resources[1]
-	actualRole, err := RoundtripKube(rbacRole)
-	if !assert.NoError(err) {
-		return
-	}
-	testhelpers.IsYAMLEqualString(assert, `---
-		apiVersion: "rbac.authorization.k8s.io/v1beta1"
-		kind: "RoleBinding"
-		metadata:
-			name: "the-name-a-role-binding"
-		subjects:
-		-	kind: "ServiceAccount"
-			name: "the-name"
-		roleRef:
-			kind: "Role"
-			name: "a-role"
-			apiGroup: "rbac.authorization.k8s.io"
-	`, actualRole)
-}
-
 func TestNewRBACAccountPSPKube(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/SUSE/fissile/helm"
+	"github.com/SUSE/fissile/model"
 )
 
 const (
@@ -56,11 +57,18 @@ func minKubeVersion(major, minor int) string {
 // on any configuration.  This is exported so the tests from other packages can
 // access them.
 func MakeBasicValues() *helm.Mapping {
+
+	psp := helm.NewMapping()
+	for _, pspName := range model.PodSecurityPolicies() {
+		psp.Add(pspName, nil)
+	}
+
 	return helm.NewMapping(
 		"kube", helm.NewMapping(
 			"external_ips", helm.NewList(),
 			"secrets_generation_counter", helm.NewNode(1, helm.Comment("Increment this counter to rotate all generated secrets")),
 			"storage_class", helm.NewMapping("persistent", "persistent", "shared", "shared"),
+			"psp", psp,
 			"hostpath_available", helm.NewNode(false, helm.Comment("Whether HostPath volume mounts are available")),
 			"registry", helm.NewMapping(
 				"hostname", "docker.io",

--- a/model/configuration.go
+++ b/model/configuration.go
@@ -26,5 +26,6 @@ type AuthRole []AuthRule
 
 // An AuthAccount is a service account for RBAC authorization
 type AuthAccount struct {
-	Roles []string `yaml:"roles"`
+	Roles             []string `yaml:"roles"`
+	PodSecurityPolicy string
 }

--- a/model/job.go
+++ b/model/job.go
@@ -56,7 +56,8 @@ type JobExposedPort struct {
 
 // JobBoshContainerization describes settings specific to containerization
 type JobBoshContainerization struct {
-	Ports []JobExposedPort `yaml:"ports"`
+	Ports             []JobExposedPort `yaml:"ports"`
+	PodSecurityPolicy string           `yaml:"pod-security-policy,omitempty"`
 }
 
 // JobContainerProperties describes job configuration

--- a/model/pod_security_policy.go
+++ b/model/pod_security_policy.go
@@ -1,0 +1,44 @@
+package model
+
+// This part of the model encapsulates fissile's knowledge of pod
+// security policies (psp). fissile actually does not know about any
+// concrete psp at all. What it knows/has are abstract names for
+// levels of privilege the writer of a manifest can assign to
+// jobs. The operator deploying the chart resulting from such a
+// manifest is then responsible for mapping the abstract names/levels
+// to concrete policies implementing them.
+
+// PodSecurityPolicies returns the names of the pod security policies
+// usable in fissile manifests
+func PodSecurityPolicies() []string {
+	return []string{
+		"nonprivileged",
+		"privileged",
+	}
+}
+
+// ValidPodSecurityPolicy checks if the argument is the name of a
+// fissile pod security policy
+func ValidPodSecurityPolicy(name string) bool {
+	for _, legal := range PodSecurityPolicies() {
+		if name == legal {
+			return true
+		}
+	}
+	return false
+}
+
+// MergePodSecurityPolicies takes two policies (names) and returns the
+// policy (name) representing the union of their privileges.
+func MergePodSecurityPolicies(policyA, policyB string) string {
+	if policyA == "privileged" || policyB == "privileged" {
+		return "privileged"
+	}
+	return "nonprivileged"
+}
+
+// LeastPodSecurityPolicy returns the name of the bottom-level pod
+// security policy (least-privileged)
+func LeastPodSecurityPolicy() string {
+	return "nonprivileged"
+}

--- a/model/pod_security_policy_test.go
+++ b/model/pod_security_policy_test.go
@@ -1,0 +1,43 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPodSecurityPolicies(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	policies := PodSecurityPolicies()
+
+	assert.Len(policies, 2)
+	assert.Contains(policies, "privileged")
+	assert.Contains(policies, "nonprivileged")
+}
+
+func TestValidPodSecurityPolicy(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	assert.True(ValidPodSecurityPolicy("privileged"))
+	assert.True(ValidPodSecurityPolicy("nonprivileged"))
+	assert.False(ValidPodSecurityPolicy("bogus"))
+}
+
+func TestMergePodSecurityPolicies(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	assert.Equal(MergePodSecurityPolicies("privileged", "privileged"), "privileged")
+	assert.Equal(MergePodSecurityPolicies("privileged", "nonprivileged"), "privileged")
+	assert.Equal(MergePodSecurityPolicies("nonprivileged", "privileged"), "privileged")
+	assert.Equal(MergePodSecurityPolicies("nonprivileged", "nonprivileged"), "nonprivileged")
+}
+
+func TestLeastPodSecurityPolicy(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	assert.Equal(LeastPodSecurityPolicy(), "nonprivileged")
+}

--- a/model/roles.go
+++ b/model/roles.go
@@ -371,6 +371,63 @@ func (m *RoleManifest) resolveRoleManifest(grapher util.ModelGrapher) error {
 		return fmt.Errorf(allErrs.Errors())
 	}
 
+	return m.resolveSecurityPolicies()
+}
+
+// resolveSecurityPolicies moves the PSP information found in
+// RoleManifest.InstanceGroup.JobReferences[].ContainerProperties.BoshContainerization.PodSecurityPolicy to
+// RoleManifest.Configuration.Authorization.Accounts[].PodSecurityPolicy
+// As service accounts can reference only one PSP the operation makes
+// clones of the base SA as needed. Note that the clones reference the same
+// roles as the base, and that the roles are not cloned.
+func (m *RoleManifest) resolveSecurityPolicies() error {
+	for _, instanceGroup := range m.InstanceGroups {
+		// Note: validateRoleRun ensured non-nil of instanceGroup.Run
+
+		pspName := GroupPolicy(instanceGroup)
+		accountName := instanceGroup.Run.ServiceAccount
+		account, ok := m.Configuration.Authorization.Accounts[accountName]
+
+		if account.PodSecurityPolicy == "" {
+			// The account has no PSP information at all.
+			// Have it use the PSP of this group
+			if !ok {
+				m.Configuration.Authorization.Accounts = make(map[string]AuthAccount)
+			}
+			account.PodSecurityPolicy = pspName
+			m.Configuration.Authorization.Accounts[accountName] = account
+			continue
+		}
+
+		if account.PodSecurityPolicy == pspName {
+			// The account's PSP matches the group-requested PSP.
+			// There is nothing to do.
+			continue
+		}
+
+		// The group references a service account which
+		// references a different PSP than the group
+		// expects. To fix this we:
+		// 1. Clone the account
+		// 2. Set the clone's PSP to the group's PSP
+		// 3. Add the clone to the map, under a new name.
+		// 4. Change the group to reference the clone
+		//
+		// However: The clone may already exist. In that case
+		// only step 4 is needed.
+
+		newAccountName := fmt.Sprintf("%s-%s", accountName, pspName)
+
+		if _, ok := m.Configuration.Authorization.Accounts[newAccountName]; !ok {
+			newAccount := account
+			newAccount.PodSecurityPolicy = pspName
+
+			m.Configuration.Authorization.Accounts[newAccountName] = newAccount
+		}
+
+		instanceGroup.Run.ServiceAccount = newAccountName
+	}
+
 	return nil
 }
 
@@ -933,6 +990,19 @@ func validateRoleRun(instanceGroup *InstanceGroup, roleManifest *RoleManifest, d
 		for idx := range job.ContainerProperties.BoshContainerization.Ports {
 			allErrs = append(allErrs, ValidateExposedPorts(instanceGroup.Name, &job.ContainerProperties.BoshContainerization.Ports[idx])...)
 		}
+
+		// Validate pod security policy, or default to least
+		if job.ContainerProperties.BoshContainerization.PodSecurityPolicy == "" {
+			job.ContainerProperties.BoshContainerization.PodSecurityPolicy = LeastPodSecurityPolicy()
+		} else {
+			if !ValidPodSecurityPolicy(job.ContainerProperties.BoshContainerization.PodSecurityPolicy) {
+				msg := fmt.Sprintf("Expected one of: %s", strings.Join(PodSecurityPolicies(), ", "))
+				ref := fmt.Sprintf("instance_groups[%s].jobs[%s].properties.bosh_containerization.pod-security-policy",
+					instanceGroup.Name, job.Name)
+				allErrs = append(allErrs, validation.Invalid(
+					ref, job.ContainerProperties.BoshContainerization.PodSecurityPolicy, msg))
+			}
+		}
 	}
 
 	if instanceGroup.Run.ServiceAccount != "" {
@@ -941,6 +1011,9 @@ func validateRoleRun(instanceGroup *InstanceGroup, roleManifest *RoleManifest, d
 			allErrs = append(allErrs, validation.NotFound(
 				fmt.Sprintf("instance_groups[%s].run.service-account", instanceGroup.Name), accountName))
 		}
+	} else {
+		// Make the default ("default" (sic!)) explicit.
+		instanceGroup.Run.ServiceAccount = "default"
 	}
 
 	// Backwards compat: convert separate volume lists to the centralized one
@@ -1449,4 +1522,19 @@ func getTemplate(propertyDefs yaml.MapSlice, property string) (interface{}, bool
 	}
 
 	return "", false
+}
+
+// GroupPolicy determines the name of the pod security policy
+// governing the specified instance group.
+func GroupPolicy(instanceGroup *InstanceGroup) string {
+	result := LeastPodSecurityPolicy()
+
+	// Note: validateRoleRun ensured non-nil of job.ContainerProperties.BoshContainerization.PodSecurityPolicy
+
+	for _, job := range instanceGroup.JobReferences {
+		result = MergePodSecurityPolicies(result,
+			job.ContainerProperties.BoshContainerization.PodSecurityPolicy)
+	}
+
+	return result
 }

--- a/model/roles.go
+++ b/model/roles.go
@@ -371,20 +371,20 @@ func (m *RoleManifest) resolveRoleManifest(grapher util.ModelGrapher) error {
 		return fmt.Errorf(allErrs.Errors())
 	}
 
-	return m.resolveSecurityPolicies()
+	return m.resolvePodSecurityPolicies()
 }
 
-// resolveSecurityPolicies moves the PSP information found in
+// resolvePodSecurityPolicies moves the PSP information found in
 // RoleManifest.InstanceGroup.JobReferences[].ContainerProperties.BoshContainerization.PodSecurityPolicy to
 // RoleManifest.Configuration.Authorization.Accounts[].PodSecurityPolicy
 // As service accounts can reference only one PSP the operation makes
 // clones of the base SA as needed. Note that the clones reference the same
 // roles as the base, and that the roles are not cloned.
-func (m *RoleManifest) resolveSecurityPolicies() error {
+func (m *RoleManifest) resolvePodSecurityPolicies() error {
 	for _, instanceGroup := range m.InstanceGroups {
 		// Note: validateRoleRun ensured non-nil of instanceGroup.Run
 
-		pspName := GroupPolicy(instanceGroup)
+		pspName := groupPodSecurityPolicy(instanceGroup)
 		accountName := instanceGroup.Run.ServiceAccount
 		account, ok := m.Configuration.Authorization.Accounts[accountName]
 
@@ -1524,9 +1524,9 @@ func getTemplate(propertyDefs yaml.MapSlice, property string) (interface{}, bool
 	return "", false
 }
 
-// GroupPolicy determines the name of the pod security policy
+// groupPodSecurityPolicy determines the name of the pod security policy
 // governing the specified instance group.
-func GroupPolicy(instanceGroup *InstanceGroup) string {
+func groupPodSecurityPolicy(instanceGroup *InstanceGroup) string {
 	result := LeastPodSecurityPolicy()
 
 	// Note: validateRoleRun ensured non-nil of job.ContainerProperties.BoshContainerization.PodSecurityPolicy

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -542,6 +542,107 @@ func TestLoadRoleManifestMissingRBACRole(t *testing.T) {
 	assert.Nil(t, roleManifest)
 }
 
+func TestLoadRoleManifestPSPMerge(t *testing.T) {
+	workDir, err := os.Getwd()
+	assert.NoError(t, err)
+
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
+	assert.NoError(t, err)
+
+	roleManifestPath := filepath.Join(workDir,
+		"../test-assets/role-manifests/model/rbac-merge-psp.yml")
+	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release}, nil)
+
+	// The loaded manifest has a single role with two jobs,
+	// requesting differing psps (The second role's request is
+	// implicit, the default).  The sole service account ends up
+	// with the union of the two, the higher. This is the account
+	// referenced by the role
+
+	assert.NotNil(t, roleManifest)
+	assert.NotNil(t, roleManifest.Configuration)
+
+	assert.Len(t, roleManifest.InstanceGroups, 1)
+	assert.NotNil(t, roleManifest.InstanceGroups[0])
+
+	assert.Len(t, roleManifest.InstanceGroups[0].JobReferences, 2)
+	assert.NotNil(t, roleManifest.InstanceGroups[0].JobReferences[0])
+	assert.NotNil(t, roleManifest.InstanceGroups[0].JobReferences[1])
+
+	assert.NotNil(t, roleManifest.InstanceGroups[0].Run)
+	assert.Equal(t, "default", roleManifest.InstanceGroups[0].Run.ServiceAccount)
+
+	// manifest value
+	assert.Equal(t, "privileged", roleManifest.InstanceGroups[0].JobReferences[0].ContainerProperties.BoshContainerization.PodSecurityPolicy)
+
+	// default
+	assert.Equal(t, "nonprivileged", roleManifest.InstanceGroups[0].JobReferences[1].ContainerProperties.BoshContainerization.PodSecurityPolicy)
+
+	assert.NotNil(t, roleManifest.Configuration.Authorization.Accounts)
+	assert.Len(t, roleManifest.Configuration.Authorization.Accounts, 1)
+	assert.Contains(t, roleManifest.Configuration.Authorization.Accounts, "default")
+	assert.Equal(t, "privileged", roleManifest.Configuration.Authorization.Accounts["default"].PodSecurityPolicy)
+}
+
+func TestLoadRoleManifestSACloneForPSPMismatch(t *testing.T) {
+	workDir, err := os.Getwd()
+	assert.NoError(t, err)
+
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
+	assert.NoError(t, err)
+
+	roleManifestPath := filepath.Join(workDir,
+		"../test-assets/role-manifests/model/rbac-clone-sa-psp-mismatch.yml")
+	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release}, nil)
+
+	// The loaded manifest has three roles with one job each. All
+	// reference the same service account (default), while
+	// requesting differing psps. This results in two service
+	// accounts, the second a clone of the first, but for the psp.
+	// Note how the third role (re)uses the account created by the
+	// second which did the cloning.
+
+	assert.NotNil(t, roleManifest)
+	assert.NotNil(t, roleManifest.Configuration)
+
+	assert.Len(t, roleManifest.InstanceGroups, 3)
+	assert.NotNil(t, roleManifest.InstanceGroups[0])
+	assert.NotNil(t, roleManifest.InstanceGroups[1])
+	assert.NotNil(t, roleManifest.InstanceGroups[2])
+
+	assert.Len(t, roleManifest.InstanceGroups[0].JobReferences, 1)
+	assert.Len(t, roleManifest.InstanceGroups[1].JobReferences, 1)
+	assert.Len(t, roleManifest.InstanceGroups[2].JobReferences, 1)
+
+	assert.NotNil(t, roleManifest.InstanceGroups[0].JobReferences[0])
+	assert.NotNil(t, roleManifest.InstanceGroups[1].JobReferences[0])
+	assert.NotNil(t, roleManifest.InstanceGroups[2].JobReferences[0])
+
+	assert.Equal(t, "privileged", roleManifest.InstanceGroups[0].JobReferences[0].ContainerProperties.BoshContainerization.PodSecurityPolicy)
+	assert.Equal(t, "nonprivileged", roleManifest.InstanceGroups[1].JobReferences[0].ContainerProperties.BoshContainerization.PodSecurityPolicy)
+	assert.Equal(t, "nonprivileged", roleManifest.InstanceGroups[2].JobReferences[0].ContainerProperties.BoshContainerization.PodSecurityPolicy)
+
+	assert.NotNil(t, roleManifest.InstanceGroups[0].Run)
+	assert.NotNil(t, roleManifest.InstanceGroups[1].Run)
+	assert.NotNil(t, roleManifest.InstanceGroups[2].Run)
+
+	assert.Equal(t, "default", roleManifest.InstanceGroups[0].Run.ServiceAccount)
+	assert.Equal(t, "default-nonprivileged", roleManifest.InstanceGroups[1].Run.ServiceAccount)
+	assert.Equal(t, "default-nonprivileged", roleManifest.InstanceGroups[2].Run.ServiceAccount)
+
+	assert.NotNil(t, roleManifest.Configuration.Authorization.Accounts)
+	assert.Len(t, roleManifest.Configuration.Authorization.Accounts, 2)
+
+	assert.Contains(t, roleManifest.Configuration.Authorization.Accounts, "default")
+	assert.Contains(t, roleManifest.Configuration.Authorization.Accounts, "default-nonprivileged")
+	assert.Equal(t, "privileged", roleManifest.Configuration.Authorization.Accounts["default"].PodSecurityPolicy)
+	assert.Equal(t, "nonprivileged", roleManifest.Configuration.Authorization.Accounts["default-nonprivileged"].PodSecurityPolicy)
+}
+
 func TestLoadRoleManifestRunGeneral(t *testing.T) {
 	t.Parallel()
 
@@ -556,6 +657,14 @@ func TestLoadRoleManifestRunGeneral(t *testing.T) {
 	}
 
 	tests := []testCase{
+		{
+			"rbac-illegal-psp.yml", []string{
+				`instance_groups[myrole].jobs[tor].properties.bosh_containerization.pod-security-policy: Invalid value: "bogus": Expected one of: nonprivileged, privileged`,
+			},
+		},
+		{
+			"rbac-ok-psp.yml", []string{},
+		},
 		{
 			"bosh-run-missing.yml", []string{
 				`instance_groups[myrole].run: Required value`,

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -547,13 +547,15 @@ func TestLoadRoleManifestPSPMerge(t *testing.T) {
 	assert.NoError(t, err)
 
 	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
-	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
-	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
-	assert.NoError(t, err)
-
 	roleManifestPath := filepath.Join(workDir,
 		"../test-assets/role-manifests/model/rbac-merge-psp.yml")
-	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release}, nil)
+	roleManifest, err := LoadRoleManifest(
+		roleManifestPath,
+		[]string{torReleasePath},
+		[]string{},
+		[]string{},
+		filepath.Join(workDir, "../test-assets/bosh-cache"),
+		nil)
 
 	// The loaded manifest has a single role with two jobs,
 	// requesting differing psps (The second role's request is
@@ -591,13 +593,15 @@ func TestLoadRoleManifestSACloneForPSPMismatch(t *testing.T) {
 	assert.NoError(t, err)
 
 	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
-	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
-	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
-	assert.NoError(t, err)
-
 	roleManifestPath := filepath.Join(workDir,
 		"../test-assets/role-manifests/model/rbac-clone-sa-psp-mismatch.yml")
-	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release}, nil)
+	roleManifest, err := LoadRoleManifest(
+		roleManifestPath,
+		[]string{torReleasePath},
+		[]string{},
+		[]string{},
+		filepath.Join(workDir, "../test-assets/bosh-cache"),
+		nil)
 
 	// The loaded manifest has three roles with one job each. All
 	// reference the same service account (default), while

--- a/test-assets/role-manifests/model/rbac-clone-sa-psp-mismatch.yml
+++ b/test-assets/role-manifests/model/rbac-clone-sa-psp-mismatch.yml
@@ -1,0 +1,26 @@
+---
+instance_groups:
+- name: myrole
+  run:
+    foo: x
+  jobs:
+  - name: tor
+    release: tor
+    properties:
+      bosh_containerization:
+        pod-security-policy: privileged
+- name: myrole2
+  run:
+    foo: x
+  jobs:
+  - name: hashmat
+    release: tor
+- name: myrole3
+  run:
+    foo: x
+  jobs:
+  - name: new_hostname
+    release: tor
+    properties:
+      bosh_containerization:
+        pod-security-policy: nonprivileged

--- a/test-assets/role-manifests/model/rbac-illegal-psp.yml
+++ b/test-assets/role-manifests/model/rbac-illegal-psp.yml
@@ -1,0 +1,11 @@
+---
+instance_groups:
+- name: myrole
+  run:
+    foo: x
+  jobs:
+  - name: tor
+    release: tor
+    properties:
+      bosh_containerization:
+        pod-security-policy: bogus

--- a/test-assets/role-manifests/model/rbac-merge-psp.yml
+++ b/test-assets/role-manifests/model/rbac-merge-psp.yml
@@ -1,0 +1,13 @@
+---
+instance_groups:
+- name: myrole
+  run:
+    foo: x
+  jobs:
+  - name: tor
+    release: tor
+    properties:
+      bosh_containerization:
+        pod-security-policy: privileged
+  - name: hashmat
+    release: tor

--- a/test-assets/role-manifests/model/rbac-ok-psp.yml
+++ b/test-assets/role-manifests/model/rbac-ok-psp.yml
@@ -1,0 +1,11 @@
+---
+instance_groups:
+- name: myrole
+  run:
+    foo: x
+  jobs:
+  - name: tor
+    release: tor
+    properties:
+      bosh_containerization:
+        pod-security-policy: privileged


### PR DESCRIPTION
Ref: https://trello.com/c/9EmTR4JL/775-3-add-psp-support-to-fissile-and-role-manifests
Ref: https://github.com/SUSE/fissile/wiki/Managing-Pod-Security-Policies

:warning: This is based on PR #382 and cannot be merged before it.
