### PR TITLE
Remove support for instance groups of the `docker` type

### DIFF
--- a/kube/pod.go
+++ b/kube/pod.go
@@ -595,35 +595,6 @@ func getContainerReadinessProbe(role *model.InstanceGroup) (helm.Node, error) {
 		// Tasks have no readiness probes
 		return nil, nil
 
-	case model.RoleTypeDocker:
-		var probe *helm.Mapping
-		if role.Run.HealthCheck != nil && role.Run.HealthCheck.Readiness != nil {
-			var complete bool
-			var err error
-			probe, complete, err = configureContainerProbe(role, "readiness", role.Run.HealthCheck.Readiness)
-			if complete || err != nil {
-				return probe.Sort(), err
-			}
-		}
-		var readinessPort *model.JobExposedPort
-		for _, job := range role.JobReferences {
-			for _, port := range job.ContainerProperties.BoshContainerization.Ports {
-				if port.Protocol == "TCP" {
-					readinessPort = &port
-					break
-				}
-			}
-		}
-		if readinessPort == nil {
-			return nil, nil
-		}
-
-		if probe == nil {
-			probe = helm.NewMapping()
-		}
-		probe.Add("tcpSocket", helm.NewMapping("port", readinessPort.InternalPort))
-		return probe.Sort(), nil
-
 	case model.RoleTypeColocatedContainer:
 		// Colocated containers have no readiness probes
 		return nil, nil

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -1639,42 +1639,6 @@ func TestPodGetContainerReadinessProbe(t *testing.T) {
 		func(sample sampleStruct) {
 			t.Run(sample.desc, func(t *testing.T) {
 				t.Parallel()
-				t.Run("docker", func(t *testing.T) {
-					t.Parallel()
-					role := podTemplateTestLoadRole(assert.New(t))
-					require.NotNil(t, role)
-					role.Run.HealthCheck = &model.HealthCheck{Readiness: sample.input}
-					role.Type = model.RoleTypeDocker
-					probe, err := getContainerReadinessProbe(role)
-					if sample.dockerError != "" {
-						assert.EqualError(t, err, sample.dockerError)
-						return
-					}
-					require.NoError(t, err)
-					if sample.dockerExpected == "" {
-						assert.Nil(t, probe)
-						return
-					}
-					require.NotNil(t, probe, "No error getting readiness probe but it was nil")
-					t.Run("kube", func(t *testing.T) {
-						t.Parallel()
-						actual, err := RoundtripKube(probe)
-						if assert.NoError(t, err) {
-							// We use subset testing here because we don't want to bother with the
-							// default timeout lengths
-							testhelpers.IsYAMLSubsetString(assert.New(t), sample.dockerExpected, actual)
-						}
-					})
-					t.Run("helm", func(t *testing.T) {
-						t.Parallel()
-						actual, err := RoundtripNode(probe, map[string]interface{}{})
-						if assert.NoError(t, err) {
-							// We use subset testing here because we don't want to bother with the
-							// default timeout lengths
-							testhelpers.IsYAMLSubsetString(assert.New(t), sample.dockerExpected, actual)
-						}
-					})
-				})
 				t.Run("bosh", func(t *testing.T) {
 					t.Parallel()
 					role := podTemplateTestLoadRole(assert.New(t))

--- a/model/instance_groups.go
+++ b/model/instance_groups.go
@@ -58,7 +58,6 @@ type RoleType string
 const (
 	RoleTypeBoshTask           = RoleType("bosh-task")           // A role that is a BOSH task
 	RoleTypeBosh               = RoleType("bosh")                // A role that is a BOSH job
-	RoleTypeDocker             = RoleType("docker")              // A role that is a raw Docker image
 	RoleTypeColocatedContainer = RoleType("colocated-container") // A role that is supposed to be used by other roles to specify a colocated container
 )
 

--- a/test-assets/role-manifests/model/docker-run-env.yml
+++ b/test-assets/role-manifests/model/docker-run-env.yml
@@ -1,7 +1,0 @@
----
-instance_groups:
-- name: dockerrole
-  type: docker
-  run:
-    env:
-    - UNKNOWN


### PR DESCRIPTION
We don't support docker roles anymore. However they create problems when moving the run property from the `InstanceGroup` to the `JobReferences` properties. `Run` is required on at least one job and docker roles don't have jobs (?). So lets remove them.

Unsure if these are all the places.