### PR TITLE
Validate bosh type

### DIFF
--- a/model/roles.go
+++ b/model/roles.go
@@ -659,6 +659,18 @@ func validateVariableType(variables Variables) validation.ErrorList {
 	allErrs := validation.ErrorList{}
 
 	for _, cv := range variables {
+		switch cv.Type {
+		case "":
+		case "certificate":
+		case "password":
+		case "rsa":
+		case "ssh":
+		default:
+			allErrs = append(allErrs, validation.Invalid(
+				fmt.Sprintf("variables[%s].type", cv.Name),
+				cv.Type, "Expected one of certificate, password, rsa, ssh or empty"))
+		}
+
 		switch cv.CVOptions.Type {
 		case "":
 			cv.CVOptions.Type = CVTypeUser
@@ -666,12 +678,12 @@ func validateVariableType(variables Variables) validation.ErrorList {
 		case CVTypeEnv:
 			if cv.CVOptions.Internal {
 				allErrs = append(allErrs, validation.Invalid(
-					fmt.Sprintf("variables[%s].type", cv.Name),
+					fmt.Sprintf("variables[%s].options.type", cv.Name),
 					cv.CVOptions.Type, `type conflicts with flag "internal"`))
 			}
 		default:
 			allErrs = append(allErrs, validation.Invalid(
-				fmt.Sprintf("variables[%s].type", cv.Name),
+				fmt.Sprintf("variables[%s].options.type", cv.Name),
 				cv.CVOptions.Type, "Expected one of user, or environment"))
 		}
 	}

--- a/model/roles.go
+++ b/model/roles.go
@@ -663,8 +663,11 @@ func validateVariableType(variables Variables) validation.ErrorList {
 		case "":
 		case "certificate":
 		case "password":
-		case "rsa":
 		case "ssh":
+		case "rsa":
+			allErrs = append(allErrs, validation.Invalid(
+				fmt.Sprintf("variables[%s].type", cv.Name),
+				cv.Type, "The rsa type is not yet supported by the secret generator"))
 		default:
 			allErrs = append(allErrs, validation.Invalid(
 				fmt.Sprintf("variables[%s].type", cv.Name),

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -485,8 +485,10 @@ func TestLoadRoleManifestBadType(t *testing.T) {
 		filepath.Join(workDir, "../test-assets/bosh-cache"),
 		nil)
 
-	require.EqualError(t, err,
+	require.Contains(t, err.Error(),
 		`variables[BAR].type: Invalid value: "invalid": Expected one of certificate, password, rsa, ssh or empty`)
+	require.Contains(t, err.Error(),
+		`variables[FOO].type: Invalid value: "rsa": The rsa type is not yet supported by the secret generator`)
 	assert.Nil(t, roleManifest)
 }
 

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -471,6 +471,25 @@ func TestLoadRoleManifestNonTemplates(t *testing.T) {
 	assert.Nil(t, roleManifest)
 }
 
+func TestLoadRoleManifestBadType(t *testing.T) {
+	workDir, err := os.Getwd()
+	assert.NoError(t, err)
+
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/model/bad-type.yml")
+	roleManifest, err := LoadRoleManifest(
+		roleManifestPath,
+		[]string{torReleasePath},
+		[]string{},
+		[]string{},
+		filepath.Join(workDir, "../test-assets/bosh-cache"),
+		nil)
+
+	require.EqualError(t, err,
+		`variables[BAR].type: Invalid value: "invalid": Expected one of certificate, password, rsa, ssh or empty`)
+	assert.Nil(t, roleManifest)
+}
+
 func TestLoadRoleManifestBadCVType(t *testing.T) {
 	workDir, err := os.Getwd()
 	assert.NoError(t, err)
@@ -486,7 +505,7 @@ func TestLoadRoleManifestBadCVType(t *testing.T) {
 		nil)
 
 	require.EqualError(t, err,
-		`variables[BAR].type: Invalid value: "bogus": Expected one of user, or environment`)
+		`variables[BAR].options.type: Invalid value: "bogus": Expected one of user, or environment`)
 	assert.Nil(t, roleManifest)
 }
 
@@ -504,7 +523,7 @@ func TestLoadRoleManifestBadCVTypeConflictInternal(t *testing.T) {
 		filepath.Join(workDir, "../test-assets/bosh-cache"),
 		nil)
 	assert.EqualError(t, err,
-		`variables[BAR].type: Invalid value: "environment": type conflicts with flag "internal"`)
+		`variables[BAR].options.type: Invalid value: "environment": type conflicts with flag "internal"`)
 	assert.Nil(t, roleManifest)
 }
 

--- a/test-assets/role-manifests/model/bad-type.yml
+++ b/test-assets/role-manifests/model/bad-type.yml
@@ -1,0 +1,39 @@
+# This role manifest checks for an invalid variable type
+---
+instance_groups:
+- name: myrole
+  environment_scripts:
+  - environ.sh
+  - /environ/script/with/absolute/path.sh
+  scripts:
+  - myrole.sh
+  - /script/with/absolute/path.sh
+  post_config_scripts:
+  - post_config_script.sh
+  - /var/vcap/jobs/myrole/pre-start
+  jobs:
+  - name: tor
+    release: tor
+    properties:
+      bosh_containerization:
+        run:
+          foo: x
+configuration:
+  templates:
+    properties.tor.hashed_control_password: '((={{ }}=)){{PELERINUL}}'
+    properties.tor.hostname: '((FOO))'
+    properties.tor.private_key.thing: '((#BAR))((HOME))((/BAR))'
+variables:
+- name: BAR
+  type: invalid
+  options:
+    description: "foo"
+- name: FOO
+  options:
+    description: "foo"
+- name: HOME
+  options:
+    description: "foo"
+- name: PELERINUL
+  options:
+    description: "foo"

--- a/test-assets/role-manifests/model/bad-type.yml
+++ b/test-assets/role-manifests/model/bad-type.yml
@@ -29,9 +29,11 @@ variables:
   options:
     description: "foo"
 - name: FOO
+  type: rsa
   options:
     description: "foo"
 - name: HOME
+  type: password
   options:
     description: "foo"
 - name: PELERINUL


### PR DESCRIPTION
* containerization also allows "" as a BOSH type
* adapt error message for fissile type, as it moved below the `options` key

https://www.pivotaltracker.com/story/show/160497595