### PR TITLE
Move writing of service accounts and roles bound to a single instance group from separate files to the file for the instance group.

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -1021,14 +1021,14 @@ func (f *Fissile) generateBoshTaskRole(outputFile *os.File, instanceGroup *model
 
 	enc := helm.NewEncoder(outputFile)
 
-	err = enc.Encode(node)
+	err = f.generateAuthCoupledToRole(enc,
+		instanceGroup.Run.ServiceAccount,
+		settings)
 	if err != nil {
 		return err
 	}
 
-	err = f.generateAuthCoupledToRole(enc,
-		instanceGroup.Run.ServiceAccount,
-		settings)
+	err = enc.Encode(node)
 	if err != nil {
 		return err
 	}
@@ -1136,6 +1136,14 @@ func (f *Fissile) generateKubeRoles(settings kube.ExportSettings) error {
 			if err != nil {
 				return err
 			}
+
+			err = f.generateAuthCoupledToRole(enc,
+				instanceGroup.Run.ServiceAccount,
+				settings)
+			if err != nil {
+				return err
+			}
+
 			err = enc.Encode(statefulSet)
 			if err != nil {
 				return err
@@ -1145,13 +1153,6 @@ func (f *Fissile) generateKubeRoles(settings kube.ExportSettings) error {
 				if err != nil {
 					return err
 				}
-			}
-
-			err = f.generateAuthCoupledToRole(enc,
-				instanceGroup.Run.ServiceAccount,
-				settings)
-			if err != nil {
-				return err
 			}
 		}
 	}

--- a/app/fissile_test.go
+++ b/app/fissile_test.go
@@ -392,6 +392,16 @@ func TestGenerateAuth(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, roleManifest)
 
+	// Force the usage counters for accounts and roles to values
+	// which causes generateAuth to write the proper files.
+	for accountName, accountSpec := range roleManifest.Configuration.Authorization.Accounts {
+		accountSpec.NumGroups = 2
+		roleManifest.Configuration.Authorization.Accounts[accountName] = accountSpec
+	}
+	for roleName := range roleManifest.Configuration.Authorization.Roles {
+		roleManifest.Configuration.Authorization.RoleUse[roleName] = 2
+	}
+
 	outDir, err := ioutil.TempDir("", "fissile-generate-auth-")
 	require.NoError(t, err)
 	defer os.RemoveAll(outDir)

--- a/model/configuration.go
+++ b/model/configuration.go
@@ -8,11 +8,17 @@ import (
 // resulting images
 type Configuration struct {
 	Authorization struct {
+		RoleUse  map[string]int
 		Roles    map[string]AuthRole    `yaml:"roles,omitempty"`
 		Accounts map[string]AuthAccount `yaml:"accounts,omitempty"`
 	} `yaml:"auth,omitempty"`
 	Templates yaml.MapSlice `yaml:"templates"`
 }
+
+// Notes: It was decided to use a separate `RoleUse` map to hold the
+// usage count for the roles to keep the API to the role manifest
+// yaml.  Going to a structure for AuthRole, with a new field for the
+// counter would change the structure of the yaml as well.
 
 // An AuthRule is a single rule for a RBAC authorization role
 type AuthRule struct {
@@ -25,7 +31,10 @@ type AuthRule struct {
 type AuthRole []AuthRule
 
 // An AuthAccount is a service account for RBAC authorization
+// The NumGroups field records the number of instance groups
+// referencing the account in question.
 type AuthAccount struct {
+	NumGroups         int
 	Roles             []string `yaml:"roles"`
 	PodSecurityPolicy string
 }


### PR DESCRIPTION
Ref: https://trello.com/c/PMrNrMOh/799-3-fissile-change-to-generate-roles-role-bindings-in-the-kube-files-if-only-one-instance-group-is-using-that-role

This change results in fissile generating a less cluttered helm chart. Accounts and roles bound just to things like a test task (irrelevant to helm), for example, will not appear in the helm chart any longer.

The effect is implemented by fissile maintaining usage/reference counters for accounts and roles when iterating over instance groups during load.  When writing files the accounts and roles with a single user are ignored by the code creating separate files, and the code writing instance groups is extended to take over that task instead.

:warning: This PR currently sits on top of https://github.com/cloudfoundry-incubator/fissile/pull/389

Defer merging until that PR is resolved one way or other.