### PR TITLE
Call `go generate` to generate docker mocks for make/vet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 
 .PHONY: all clean format lint vet bindata build test docker-deps reap dist
 
-all: clean format lint bindata docker-deps build test vet
+all: clean format lint bindata vet docker-deps build test
 
 clean:
 	${GIT_ROOT}/make/clean

--- a/make/vet
+++ b/make/vet
@@ -6,6 +6,8 @@ set -o errexit
 
 printf "%b==> Vetting %b\n" "${OK_COLOR}" "${ERROR_COLOR}"
 
+# make/bindata must be run first to generate scripts/compilation/compilation.go
+go generate ./docker/ # for mocks
 go vet $(go list -f '{{ .ImportPath }}' ./... | sed '\@fissile/scripts@d ; \@fissile/mustache@d ; \@/vendor/@d')
 
 printf "%b" "${NO_COLOR}"


### PR DESCRIPTION
`make/vet` still requires `make/bindata` to be run first to generate `scripts/compilation/compilation.go`