### PR TITLE
For readiness probe, ensure that monit daemon is up

### DIFF
--- a/scripts/dockerfiles/readiness-probe.sh
+++ b/scripts/dockerfiles/readiness-probe.sh
@@ -14,13 +14,13 @@
 
 ###
 
-set -o errexit -o nounset
+set -o errexit -o nounset -o pipefail
 
 # Grab monit port
 monit_port=$(awk '/httpd port/ { print $4 }' /etc/monitrc)
 
 # Check that monit thinks everything is ready
-curl -s -u admin:${MONIT_PASSWORD} http://127.0.0.1:${monit_port}/_status | gawk '
+curl -s -u admin:"${MONIT_PASSWORD}" http://127.0.0.1:"${monit_port}"/_status | gawk '
     BEGIN                                                     { status = 0 }
     $1 == "status" && $2 != "running" && $2 != "accessible"   { print ; status = 1 }
     END                                                       { exit status }
@@ -52,7 +52,7 @@ if test -n "${FISSILE_ACTIVE_PASSIVE_PROBE:-}" ; then
         return $?
     }
 
-    if eval ${FISSILE_ACTIVE_PASSIVE_PROBE} ; then
+    if eval "${FISSILE_ACTIVE_PASSIVE_PROBE}" ; then
         update_readiness true
     else
         update_readiness false


### PR DESCRIPTION
The monit status HTTP curl call should fail

- when monit daemon is not up
- Add pipefail to produce a failure return code if any cmd of
  the pipe fails when checking the monit status
- Double quote vars to prevent globbing/word splitting(SC2086 shellcheck)