### PR TITLE
[README]Update Fissile build procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ agent.
 ## Getting fissile
 
 ### Prerequisites
-Building fissile needs [Go 1.7] or higher and [Docker].
+Building fissile needs [Go 1.9] or higher and [Docker].
 
-[Go 1.7]: https://golang.org/doc/install
+[Go 1.9]: https://golang.org/doc/install
 [Docker]: https://www.docker.com
 
 ### Build procedure
@@ -21,6 +21,8 @@ Fissile requires generated code using additional tools, and therefore isn't
 `go get`-able.
 
 ```
+$ make src                                      # make the directory src 
+$ export $GOPATH=$PWD                           # set GOPATH
 $ go get -d code.cloudfoundry.org/fissile       # Download sources
 $ cd $GOPATH/src/code.cloudfoundry.org/fissile
 $ make tools                              # install required tools; only needed first time


### PR DESCRIPTION
I'm following the steps to build Fissile [here](https://github.com/cloudfoundry-incubator/fissile#build-procedure)

- Updated Go version, as Go 1.7 and 1.8 not works for me and 1.9 works well.
- Added minor details to build Fissile
```
zhanggongs-mbp:fissile (upstream_develop*) $ gvm use go1.7                                                    
zhanggongs-mbp:fissile (upstream_develop*) $ make all     
/Users/zhanggong/zhgworkspace/fissile/src/code.cloudfoundry.org/fissile/make/clean
==> Cleaning 
/Users/zhanggong/zhgworkspace/fissile/src/code.cloudfoundry.org/fissile/make/format
==> Formatting 
/Users/zhanggong/zhgworkspace/fissile/src/code.cloudfoundry.org/fissile/compilator/storage.go:36:28: expected type, found '='
/Users/zhanggong/zhgworkspace/fissile/src/code.cloudfoundry.org/fissile/compilator/storage.go:36:30: expected ';', found 'func'
make: *** [format] Error 2


zhanggongs-mbp:fissile (upstream_develop*) $ gvm use go1.8                                      
Now using version go1.8                
zhanggongs-mbp:fissile (upstream_develop*) $ make all                                           
/Users/zhanggong/zhgworkspace/fissile/src/code.cloudfoundry.org/fissile/make/clean
==> Cleaning 
/Users/zhanggong/zhgworkspace/fissile/src/code.cloudfoundry.org/fissile/make/format
==> Formatting 
/Users/zhanggong/zhgworkspace/fissile/src/code.cloudfoundry.org/fissile/make/lint
==> Linting
/Users/zhanggong/zhgworkspace/fissile/src/code.cloudfoundry.org/fissile/make/bindata
==> Binary Data 
/Users/zhanggong/zhgworkspace/fissile/src/code.cloudfoundry.org/fissile/make/vet
==> Vetting 
vet: compilator/storage.go: compilator/storage.go:36:28: expected type, found '='
vet: no files checked
exit status 1
make: *** [vet] Error 1

```
