### PR TITLE
Replace skiff-role-name with app.kubernetes.io/component

### DIFF
--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -222,7 +222,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 				replicas: 1
 				selector:
 					matchLabels:
-						skiff-role-name: "some-group"
+						app.kubernetes.io/component: "some-group"
 				template:
 					metadata:
 						name: "some-group"
@@ -243,7 +243,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 								-	podAffinityTerm:
 										labelSelector:
 											matchExpressions:
-											-	key: "skiff-role-name"
+											-	key: "app.kubernetes.io/component"
 												operator: "In"
 												values:
 												-	"some-group"

--- a/kube/registry_credentials_test.go
+++ b/kube/registry_credentials_test.go
@@ -31,7 +31,7 @@ func TestMakeRegistryCredentialsKube(t *testing.T) {
 		metadata:
 			name: "registry-credentials"
 			labels:
-				skiff-role-name: "registry-credentials"
+				app.kubernetes.io/component: "registry-credentials"
 		type: "kubernetes.io/dockercfg"
 	`, actual)
 }

--- a/kube/secret_test.go
+++ b/kube/secret_test.go
@@ -32,7 +32,7 @@ func TestMakeSecretsEmpty(t *testing.T) {
 			metadata:
 				name: "secrets"
 				labels:
-					skiff-role-name: "secrets"
+					app.kubernetes.io/component: "secrets"
 		`
 		testhelpers.IsYAMLEqualString(assert, expected, actual)
 	})
@@ -192,7 +192,7 @@ func TestMakeSecretsKube(t *testing.T) {
 		metadata:
 			name: "secrets"
 			labels:
-				skiff-role-name: "secrets"
+				app.kubernetes.io/component: "secrets"
 	`, varConstB64, varValuedB64, varStructuredB64), actual)
 }
 

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -70,7 +70,7 @@ func TestServiceKube(t *testing.T) {
 				port: 443
 				targetPort: 443
 			selector:
-				skiff-role-name: myrole
+				app.kubernetes.io/component: myrole
 	`, actual)
 }
 
@@ -114,7 +114,7 @@ func TestServiceHelm(t *testing.T) {
 					protocol: "TCP"
 					targetPort: 443
 				selector:
-					skiff-role-name: "myrole"
+					app.kubernetes.io/component: "myrole"
 		`, actual)
 	})
 
@@ -142,7 +142,7 @@ func TestServiceHelm(t *testing.T) {
 					protocol: "TCP"
 					targetPort: 443
 				selector:
-					skiff-role-name: "myrole"
+					app.kubernetes.io/component: "myrole"
 		`, actual)
 	})
 }
@@ -181,7 +181,7 @@ func TestHeadlessServiceKube(t *testing.T) {
 				# targetPort must be undefined for headless services
 				targetPort: 0
 			selector:
-				skiff-role-name: myrole
+				app.kubernetes.io/component: myrole
 			clusterIP: None
 	`, actual)
 }
@@ -228,7 +228,7 @@ func TestHeadlessServiceHelm(t *testing.T) {
 					protocol: "TCP"
 					targetPort: 0
 				selector:
-					skiff-role-name: "myrole"
+					app.kubernetes.io/component: "myrole"
 		`, actual)
 	})
 
@@ -257,7 +257,7 @@ func TestHeadlessServiceHelm(t *testing.T) {
 					protocol: "TCP"
 					targetPort: 0
 				selector:
-					skiff-role-name: "myrole"
+					app.kubernetes.io/component: "myrole"
 		`, actual)
 	})
 }
@@ -291,7 +291,7 @@ func TestPublicServiceKube(t *testing.T) {
 				port: 443
 				targetPort: 443
 			selector:
-				skiff-role-name: myrole
+				app.kubernetes.io/component: myrole
 	`, actual)
 }
 
@@ -335,7 +335,7 @@ func TestPublicServiceHelm(t *testing.T) {
 					protocol: "TCP"
 					targetPort: 443
 				selector:
-					skiff-role-name: "myrole"
+					app.kubernetes.io/component: "myrole"
 		`, actual)
 	})
 
@@ -360,7 +360,7 @@ func TestPublicServiceHelm(t *testing.T) {
 					protocol: "TCP"
 					targetPort: 443
 				selector:
-					skiff-role-name: "myrole"
+					app.kubernetes.io/component: "myrole"
 				type:	LoadBalancer
 		`, actual)
 	})
@@ -460,7 +460,7 @@ func TestActivePassiveService(t *testing.T) {
 													protocol: TCP
 													targetPort: 0
 												selector:
-													skiff-role-name: myrole
+													app.kubernetes.io/component: myrole
 													skiff-role-active: "true"
 										`
 										testhelpers.IsYAMLEqualString(assert.New(t), expected, actual)
@@ -488,7 +488,7 @@ func TestActivePassiveService(t *testing.T) {
 													protocol: TCP
 													targetPort: 0
 												selector:
-													skiff-role-name: myrole
+													app.kubernetes.io/component: myrole
 													skiff-role-active: "true"
 										`
 										testhelpers.IsYAMLEqualString(assert.New(t), expected, actual)
@@ -520,7 +520,7 @@ func TestActivePassiveService(t *testing.T) {
 												protocol: TCP
 												targetPort: 443
 											selector:
-												skiff-role-name: myrole
+												app.kubernetes.io/component: myrole
 												skiff-role-active: "true"
 									`
 									testhelpers.IsYAMLEqualString(assert.New(t), expected, actual)
@@ -544,7 +544,7 @@ func TestActivePassiveService(t *testing.T) {
 												protocol: TCP
 												targetPort: 443
 											selector:
-												skiff-role-name: myrole
+												app.kubernetes.io/component: myrole
 												skiff-role-active: "true"
 									`
 									switch variant {

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -98,7 +98,7 @@ func TestStatefulSetPorts(t *testing.T) {
 					# targetPort must be undefined for headless services
 					targetPort: 0
 				selector:
-					skiff-role-name: myrole
+					app.kubernetes.io/component: myrole
 				clusterIP: None
 		-
 			# This is the per-pod naming port
@@ -117,7 +117,7 @@ func TestStatefulSetPorts(t *testing.T) {
 					# targetPort must be undefined for headless services
 					targetPort: 0
 				selector:
-					skiff-role-name: myrole
+					app.kubernetes.io/component: myrole
 				clusterIP: None
 		-
 			# This is the private service port
@@ -134,7 +134,7 @@ func TestStatefulSetPorts(t *testing.T) {
 						port: 443
 						targetPort: 443
 				selector:
-					skiff-role-name: myrole
+					app.kubernetes.io/component: myrole
 		-
 			# This is the public service port
 			metadata:
@@ -146,7 +146,7 @@ func TestStatefulSetPorts(t *testing.T) {
 						port: 443
 						targetPort: 443
 				selector:
-					skiff-role-name: myrole
+					app.kubernetes.io/component: myrole
 		-
 			# This is the actual StatefulSet
 			metadata:
@@ -157,7 +157,7 @@ func TestStatefulSetPorts(t *testing.T) {
 				template:
 					metadata:
 						labels:
-							skiff-role-name: myrole
+							app.kubernetes.io/component: myrole
 						name: myrole
 					spec:
 						containers:
@@ -246,7 +246,7 @@ func TestStatefulSetServices(t *testing.T) {
 									protocol: TCP
 									targetPort: 0
 								selector:
-									skiff-role-name: myrole
+									app.kubernetes.io/component: myrole
 							`, actual)
 						}
 						if assert.NotNil(t, genericService, "Generic instance group service not found") {
@@ -280,7 +280,7 @@ func TestStatefulSetServices(t *testing.T) {
 									protocol: TCP
 									targetPort: 0
 								selector:
-									skiff-role-name: myrole
+									app.kubernetes.io/component: myrole
 							`, actual)
 						}
 						if assert.NotNil(t, publicService, "Public service not found") {
@@ -309,7 +309,7 @@ func TestStatefulSetServices(t *testing.T) {
 									protocol: TCP
 									targetPort: 443
 								selector:
-									skiff-role-name: myrole
+									app.kubernetes.io/component: myrole
 							`, actual)
 						}
 						if assert.NotNil(t, internalService, "Internal service not found") {
@@ -342,7 +342,7 @@ func TestStatefulSetServices(t *testing.T) {
 									protocol: TCP
 									targetPort: 443
 								selector:
-									skiff-role-name: myrole
+									app.kubernetes.io/component: myrole
 							`, actual)
 						}
 					})
@@ -438,7 +438,7 @@ func TestStatefulSetVolumesKube(t *testing.T) {
 			template:
 				metadata:
 					labels:
-						skiff-role-name: myrole
+						app.kubernetes.io/component: myrole
 					name: myrole
 				spec:
 					containers:
@@ -514,7 +514,7 @@ func TestStatefulSetVolumesWithAnnotationKube(t *testing.T) {
 			template:
 				metadata:
 					labels:
-						skiff-role-name: myrole
+						app.kubernetes.io/component: myrole
 					name: myrole
 				spec:
 					containers:
@@ -605,7 +605,7 @@ func TestStatefulSetVolumesHelm(t *testing.T) {
 			template:
 				metadata:
 					labels:
-						skiff-role-name: myrole
+						app.kubernetes.io/component: myrole
 					name: myrole
 				spec:
 					containers:
@@ -701,7 +701,7 @@ func TestStatefulSetEmptyDirVolumesKube(t *testing.T) {
 			template:
 				metadata:
 					labels:
-						skiff-role-name: myrole
+						app.kubernetes.io/component: myrole
 					name: myrole
 				spec:
 					containers:

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	// RoleNameLabel is a thing
-	RoleNameLabel = "skiff-role-name"
+	// RoleNameLabel is the recommended kube label to specify the rolename
+	RoleNameLabel = "app.kubernetes.io/component"
 	// VolumeStorageClassAnnotation is the annotation label for storage/v1beta1/StorageClass
 	VolumeStorageClassAnnotation = "volume.beta.kubernetes.io/storage-class"
 )
@@ -39,7 +39,9 @@ func newKubeConfig(settings ExportSettings, apiVersion, kind string, name string
 	mapping.Add("metadata", newObjectMeta(name))
 	if settings.CreateHelmChart {
 		labels := mapping.Get("metadata").Get("labels").(*helm.Mapping)
-		labels.Add("app.kubernetes.io/component", name)
+		// XXX skiff-role-name is the legacy RoleNameLabel and will be removed in a future release
+		labels.Add("skiff-role-name", name)
+		// "app.kubernetes.io/component" (aka RoleNameLabel) already added by newObjectMeta()
 		labels.Add("app.kubernetes.io/instance", `{{ .Release.Name }}`)
 		labels.Add("app.kubernetes.io/managed-by", `{{ .Release.Service }}`)
 		labels.Add("app.kubernetes.io/name", `{{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}`)

--- a/kube/utils_test.go
+++ b/kube/utils_test.go
@@ -40,7 +40,7 @@ func TestNewObjectMeta(t *testing.T) {
 	testhelpers.IsYAMLEqualString(assert, `---
 		name: "thename"
 		labels:
-			skiff-role-name: "thename"
+			app.kubernetes.io/component: "thename"
 	`, actual)
 }
 
@@ -56,7 +56,7 @@ func TestNewSelector(t *testing.T) {
 	}
 	testhelpers.IsYAMLEqualString(assert, `---
 		matchLabels:
-			skiff-role-name: "thename"
+			app.kubernetes.io/component: "thename"
 	`, actual)
 }
 
@@ -76,7 +76,7 @@ func TestNewKubeConfig(t *testing.T) {
 		metadata:
 			name: "thename"
 			labels:
-				skiff-role-name: "thename"
+				app.kubernetes.io/component: "thename"
 	`, actual)
 }
 

--- a/test-assets/role-manifests/kube/pod-with-valid-pod-anti-affinity.yml
+++ b/test-assets/role-manifests/kube/pod-with-valid-pod-anti-affinity.yml
@@ -18,7 +18,7 @@ instance_groups:
                 podAffinityTerm:
                   labelSelector:
                     matchExpressions:
-                    - key: "skiff-role-name"
+                    - key: "app.kubernetes.io/component"
                       operator: In
                       values:
                       - some-group


### PR DESCRIPTION
We'll keep the skiff-role-name label around for a while in case it is being used by end users.