### PR TITLE
Call make/bindata whenever required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 
 .PHONY: all clean format lint vet bindata build test docker-deps reap dist
 
-all: clean format lint bindata vet docker-deps build test
+all: clean format lint vet test build
 
 clean:
 	${GIT_ROOT}/make/clean
@@ -21,9 +21,6 @@ lint:
 
 vet:
 	${GIT_ROOT}/make/vet
-
-bindata:
-	${GIT_ROOT}/make/bindata
 
 build:
 	${GIT_ROOT}/make/build
@@ -43,7 +40,6 @@ tools:
 show-versions:
 	make/show-versions
 
-# If this fails, try running 'make bindata' and rerun 'make test'
 test:
 	${GIT_ROOT}/make/test
 

--- a/make/test
+++ b/make/test
@@ -2,6 +2,10 @@
 
 set -o errexit
 
+GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
+
+${GIT_ROOT}/make/bindata
+
 . make/include/colors.sh
 
 printf "%b==> Testing %b\n" "${OK_COLOR}" "${NO_COLOR}"

--- a/make/vet
+++ b/make/vet
@@ -2,6 +2,10 @@
 
 set -o errexit
 
+GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
+
+${GIT_ROOT}/make/bindata
+
 . make/include/colors.sh
 
 printf "%b==> Vetting %b\n" "${OK_COLOR}" "${ERROR_COLOR}"


### PR DESCRIPTION
This makes it possible to run all the build steps of `make all` in arbitrary order, e.g. `make clean vet`, `make clean test` etc all work now.

Running `make all` will now result in running make/bindata multiple times. But given that it takes just a couple of milliseconds this doesn't really matter.

The docker images are not required for any of the other build steps, so they are no longer pulled as part of the `make all` command.