### PR TITLE
make/docker-deps is a prereq for make/test

### DIFF
--- a/make/test
+++ b/make/test
@@ -5,6 +5,7 @@ set -o errexit
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
 ${GIT_ROOT}/make/bindata
+${GIT_ROOT}/make/docker-deps
 
 . make/include/colors.sh
 


### PR DESCRIPTION
make/docker-deps was erroneously removed in #421 because it isn't used for building the tool.

It is required for running the tests though.