### PR TITLE
helm+kube: default to not allowing privilege escalation

### DIFF
--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -270,6 +270,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 									command: [ /opt/fissile/readiness-probe.sh ]
 							resources: ~
 							securityContext:
+								allowPrivilegeEscalation: false
 								capabilities:
 									add:	~
 							volumeMounts: ~

--- a/kube/job_test.go
+++ b/kube/job_test.go
@@ -204,6 +204,7 @@ func TestJobHelm(t *testing.T) {
 						readinessProbe: ~
 						resources: ~
 						securityContext:
+							allowPrivilegeEscalation: false
 							capabilities:
 								add:	~
 						volumeMounts: ~

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -1800,6 +1800,7 @@ func TestPodPreFlightHelm(t *testing.T) {
 				readinessProbe: ~
 				resources: ~
 				securityContext:
+					allowPrivilegeEscalation: false
 					capabilities:
 						add:	~
 				volumeMounts: ~
@@ -1908,6 +1909,7 @@ func TestPodPostFlightHelm(t *testing.T) {
 				readinessProbe: ~
 				resources: ~
 				securityContext:
+					allowPrivilegeEscalation: false
 					capabilities:
 						add:	~
 				volumeMounts: ~
@@ -2028,6 +2030,7 @@ func TestPodMemoryHelmDisabled(t *testing.T) {
 					requests:
 					limits:
 				securityContext:
+					allowPrivilegeEscalation: false
 					capabilities:
 						add:	~
 				volumeMounts: ~
@@ -2111,6 +2114,7 @@ func TestPodMemoryHelmActive(t *testing.T) {
 					limits:
 						memory: "10Mi"
 				securityContext:
+					allowPrivilegeEscalation: false
 					capabilities:
 						add:	~
 				volumeMounts: ~
@@ -2229,6 +2233,7 @@ func TestPodCPUHelmDisabled(t *testing.T) {
 					requests:
 					limits:
 				securityContext:
+					allowPrivilegeEscalation: false
 					capabilities:
 						add:	~
 				volumeMounts: ~
@@ -2312,6 +2317,7 @@ func TestPodCPUHelmActive(t *testing.T) {
 					limits:
 						cpu: "10m"
 				securityContext:
+					allowPrivilegeEscalation: false
 					capabilities:
 						add:	~
 				volumeMounts: ~
@@ -2345,6 +2351,7 @@ func TestGetSecurityContextCapList(t *testing.T) {
 			return
 		}
 		testhelpers.IsYAMLEqualString(assert, `---
+			allowPrivilegeEscalation: false
 			capabilities:
 				add:
 				-	"SOMETHING"
@@ -2368,6 +2375,7 @@ func TestGetSecurityContextCapList(t *testing.T) {
 				return
 			}
 			testhelpers.IsYAMLEqualString(assert, `---
+				allowPrivilegeEscalation: false
 				capabilities:
 					add:
 					-	"SOMETHING"
@@ -2384,6 +2392,7 @@ func TestGetSecurityContextCapList(t *testing.T) {
 				return
 			}
 			testhelpers.IsYAMLEqualString(assert, `---
+				allowPrivilegeEscalation: false
 				privileged: true
 			`, actual)
 		})
@@ -2398,6 +2407,7 @@ func TestGetSecurityContextCapList(t *testing.T) {
 				return
 			}
 			testhelpers.IsYAMLEqualString(assert, `---
+				allowPrivilegeEscalation: false
 				capabilities:
 					add:
 					-	"SOMETHING"
@@ -2423,7 +2433,17 @@ func TestGetSecurityContextNil(t *testing.T) {
 	t.Run("Kube", func(t *testing.T) {
 		t.Parallel()
 		sc := getSecurityContext(role, false)
-		assert.Nil(sc)
+		if !assert.NotNil(sc) {
+			return
+		}
+
+		actual, err := RoundtripKube(sc)
+		if !assert.NoError(err) {
+			return
+		}
+		testhelpers.IsYAMLEqualString(assert, `---
+			allowPrivilegeEscalation: false
+		`, actual)
 	})
 
 	t.Run("Helm", func(t *testing.T) {
@@ -2443,6 +2463,7 @@ func TestGetSecurityContextNil(t *testing.T) {
 				return
 			}
 			testhelpers.IsYAMLEqualString(assert, `---
+				allowPrivilegeEscalation: false
 				capabilities:
 					add:	~
 			`, actual)
@@ -2458,6 +2479,7 @@ func TestGetSecurityContextNil(t *testing.T) {
 				return
 			}
 			testhelpers.IsYAMLEqualString(assert, `---
+				allowPrivilegeEscalation: false
 				privileged: true
 			`, actual)
 		})
@@ -2472,6 +2494,7 @@ func TestGetSecurityContextNil(t *testing.T) {
 				return
 			}
 			testhelpers.IsYAMLEqualString(assert, `---
+				allowPrivilegeEscalation: false
 				capabilities:
 					add:
 					-	SOMETHING

--- a/model/instance_groups.go
+++ b/model/instance_groups.go
@@ -526,6 +526,21 @@ func (g *InstanceGroup) IsPrivileged() bool {
 	return false
 }
 
+// PodSecurityPolicy determines the name of the pod security policy
+// governing the specified instance group.
+func (g *InstanceGroup) PodSecurityPolicy() string {
+	result := LeastPodSecurityPolicy()
+
+	// Note: validateRoleRun ensured non-nil of job.ContainerProperties.BoshContainerization.PodSecurityPolicy
+
+	for _, job := range g.JobReferences {
+		result = MergePodSecurityPolicies(result,
+			job.ContainerProperties.BoshContainerization.PodSecurityPolicy)
+	}
+
+	return result
+}
+
 // IsColocated tests if the role is of type ColocatedContainer, or
 // not. It returns true if this role is of that type, or false otherwise.
 func (g *InstanceGroup) IsColocated() bool {

--- a/model/pod_security_policy.go
+++ b/model/pod_security_policy.go
@@ -8,12 +8,18 @@ package model
 // manifest is then responsible for mapping the abstract names/levels
 // to concrete policies implementing them.
 
+// Pod security policy constants
+const (
+	PodSecurityPolicyNonPrivileged = "nonprivileged"
+	PodSecurityPolicyPrivileged    = "privileged"
+)
+
 // PodSecurityPolicies returns the names of the pod security policies
 // usable in fissile manifests
 func PodSecurityPolicies() []string {
 	return []string{
-		"nonprivileged",
-		"privileged",
+		PodSecurityPolicyNonPrivileged,
+		PodSecurityPolicyPrivileged,
 	}
 }
 
@@ -31,14 +37,14 @@ func ValidPodSecurityPolicy(name string) bool {
 // MergePodSecurityPolicies takes two policies (names) and returns the
 // policy (name) representing the union of their privileges.
 func MergePodSecurityPolicies(policyA, policyB string) string {
-	if policyA == "privileged" || policyB == "privileged" {
-		return "privileged"
+	if policyA == PodSecurityPolicyPrivileged || policyB == PodSecurityPolicyPrivileged {
+		return PodSecurityPolicyPrivileged
 	}
-	return "nonprivileged"
+	return PodSecurityPolicyNonPrivileged
 }
 
 // LeastPodSecurityPolicy returns the name of the bottom-level pod
 // security policy (least-privileged)
 func LeastPodSecurityPolicy() string {
-	return "nonprivileged"
+	return PodSecurityPolicyNonPrivileged
 }

--- a/model/roles.go
+++ b/model/roles.go
@@ -371,7 +371,7 @@ func (m *RoleManifest) resolvePodSecurityPolicies() error {
 	for _, instanceGroup := range m.InstanceGroups {
 		// Note: validateRoleRun ensured non-nil of instanceGroup.Run
 
-		pspName := groupPodSecurityPolicy(instanceGroup)
+		pspName := instanceGroup.PodSecurityPolicy()
 		accountName := instanceGroup.Run.ServiceAccount
 		account, ok := m.Configuration.Authorization.Accounts[accountName]
 
@@ -624,19 +624,4 @@ func getTemplate(propertyDefs yaml.MapSlice, property string) (interface{}, bool
 	}
 
 	return "", false
-}
-
-// groupPodSecurityPolicy determines the name of the pod security policy
-// governing the specified instance group.
-func groupPodSecurityPolicy(instanceGroup *InstanceGroup) string {
-	result := LeastPodSecurityPolicy()
-
-	// Note: validateRoleRun ensured non-nil of job.ContainerProperties.BoshContainerization.PodSecurityPolicy
-
-	for _, job := range instanceGroup.JobReferences {
-		result = MergePodSecurityPolicies(result,
-			job.ContainerProperties.BoshContainerization.PodSecurityPolicy)
-	}
-
-	return result
 }


### PR DESCRIPTION
When using pod security policies, it is likely that (for the unprivileged policy at least) we are not allowed to escalate privileges. This means that pods will fail to start if they ask for escalation.

For some crazy reason, kube seems to default `allowPrivilegeEscalation` to true when not supplied (when fetching the pod metadata, not when running); this means that attempting to patch the pod (to update the configgin annotations) will fail because even a no-op patch is considered an escalation.  Fix this by explicitly marking the pods as not requiring the escalation.