### PR TITLE
Fix helm charts with numeric versions

### DIFF
--- a/kube/utils.go
+++ b/kube/utils.go
@@ -45,7 +45,7 @@ func newKubeConfig(settings ExportSettings, apiVersion, kind string, name string
 		labels.Add("app.kubernetes.io/instance", `{{ .Release.Name }}`)
 		labels.Add("app.kubernetes.io/managed-by", `{{ .Release.Service }}`)
 		labels.Add("app.kubernetes.io/name", `{{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}`)
-		labels.Add("app.kubernetes.io/version", `{{ default .Chart.Version .Chart.AppVersion }}`)
+		labels.Add("app.kubernetes.io/version", `{{ default .Chart.Version .Chart.AppVersion | quote }}`)
 		// labels.Add("app.kubernetes.io/part-of", `???`)
 		labels.Add("helm.sh/chart", `{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}`)
 	}

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -42,12 +42,12 @@ func newKubeConfig(settings ExportSettings, apiVersion, kind string, name string
 		// XXX skiff-role-name is the legacy RoleNameLabel and will be removed in a future release
 		labels.Add("skiff-role-name", name)
 		// "app.kubernetes.io/component" (aka RoleNameLabel) already added by newObjectMeta()
-		labels.Add("app.kubernetes.io/instance", `{{ .Release.Name }}`)
-		labels.Add("app.kubernetes.io/managed-by", `{{ .Release.Service }}`)
-		labels.Add("app.kubernetes.io/name", `{{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}`)
+		labels.Add("app.kubernetes.io/instance", `{{ .Release.Name | quote }}`)
+		labels.Add("app.kubernetes.io/managed-by", `{{ .Release.Service | quote }}`)
+		labels.Add("app.kubernetes.io/name", `{{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}`)
 		labels.Add("app.kubernetes.io/version", `{{ default .Chart.Version .Chart.AppVersion | quote }}`)
 		// labels.Add("app.kubernetes.io/part-of", `???`)
-		labels.Add("helm.sh/chart", `{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}`)
+		labels.Add("helm.sh/chart", `{{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}`)
 	}
 	return mapping
 }


### PR DESCRIPTION
Chart versions can be numeric, but kubernetes chokes on numeric label
values, resulting in errors like

```
Error: release my-nats failed: Secret in version "v1" cannot be handled
as a Secret: v1.Secret: Type: ObjectMeta: v1.ObjectMeta: Namespace:
Name: Labels: ReadString: expects " or n, but found 1, error found in
 #10 byte of ...|version":1,"helm.sh/|..., bigger context
...|s.io/name":"my-nats","app.kubernetes.io/version":1,"helm.sh/chart":"my-nats-1","skiff-role-name":"re|...
```

To fix this the version label value is always quoted.