### PR TITLE
Add a matchLabels selector to stateful sets as well

### DIFF
--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -30,6 +30,7 @@ func NewStatefulSet(role *model.InstanceGroup, settings ExportSettings, grapher 
 
 	spec := helm.NewMapping()
 	spec.Add("serviceName", fmt.Sprintf("%s-set", role.Name))
+	spec.Add("selector", newSelector(role.Name))
 	spec.Add("template", podTemplate)
 	// "updateStrategy" is new in kube 1.7, so we don't add anything to non-helm configs
 	// The default behaviour is "OnDelete"


### PR DESCRIPTION
This is required to work around
https://github.com/helm/charts/issues/7726, without it we see errors like

```
Error: UPGRADE FAILED: StatefulSet.apps "nats" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app.kubernetes.io/managed-by":"Tiller", "app.kubernetes.io/name":"my-nats", "app.kubernetes.io/version":"", "helm.sh/chart":"my-nats-10", "skiff-role-name":"nats", "app.kubernetes.io/component":"nats", "app.kubernetes.io/instance":"my-nats"}: `selector` does not match template `labels`
```

during helm upgrades.