### PR TITLE
Add support for embedded deployment manifests in the values.yml

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -881,6 +881,16 @@ func (f *Fissile) GenerateKube(defaultFiles []string, settings kube.ExportSettin
 		return err
 	}
 
+	manifestSecret, err := kube.MakeBoshDeploymentManifestSecret(settings)
+	if err != nil {
+		return err
+	}
+
+	err = f.generateSecrets("deployment-manifest-secret.yaml", manifestSecret, settings)
+	if err != nil {
+		return err
+	}
+
 	if settings.CreateHelmChart {
 		values, err := kube.MakeValues(settings)
 		if err != nil {

--- a/kube/bosh_deployment_manifest_secret.go
+++ b/kube/bosh_deployment_manifest_secret.go
@@ -1,0 +1,27 @@
+package kube
+
+import "code.cloudfoundry.org/fissile/helm"
+
+// MakeBoshDeploymentManifestSecret generates a template for a secret that holds the content of a BOSH deployment manifest
+func MakeBoshDeploymentManifestSecret(settings ExportSettings) (helm.Node, error) {
+	value := ""
+	if settings.CreateHelmChart {
+		value = "{{ .Values.bosh | toYaml | b64enc }}"
+	}
+
+	secret := newKubeConfig(settings, "v1", "Secret", "deployment-manifest", boshDeploymentManifestCondition(settings))
+
+	data := helm.NewMapping("deployment-manifest", value)
+	secret.Add("data", data)
+	secret.Add("type", "Opaque")
+
+	return secret, nil
+}
+
+// boshDeploymentManifestCondition creates a block condition checking for an embedded bosh deployment manifest
+func boshDeploymentManifestCondition(settings ExportSettings) helm.NodeModifier {
+	if settings.CreateHelmChart {
+		return helm.Block("if .Values.bosh")
+	}
+	return nil
+}

--- a/kube/bosh_deployment_manifest_secret_test.go
+++ b/kube/bosh_deployment_manifest_secret_test.go
@@ -1,0 +1,77 @@
+package kube
+
+import (
+	b64 "encoding/base64"
+	"testing"
+
+	"code.cloudfoundry.org/fissile/testhelpers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeBoshDeploymentManifestSecretKube(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	manifestSecret, err := MakeBoshDeploymentManifestSecret(ExportSettings{})
+
+	if !assert.NoError(err) {
+		return
+	}
+
+	actual, err := RoundtripKube(manifestSecret)
+	if !assert.NoError(err) {
+		return
+	}
+	testhelpers.IsYAMLEqualString(assert, `---
+		apiVersion: "v1"
+		data:
+		  deployment-manifest: ""
+		kind: "Secret"
+		metadata:
+			name: "deployment-manifest"
+			labels:
+				app.kubernetes.io/component: "deployment-manifest"
+		type: "Opaque"
+	`, actual)
+}
+
+func TestMakeBoshDeploymentManifestSecretHelm(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	manifestSecret, err := MakeBoshDeploymentManifestSecret(ExportSettings{
+		CreateHelmChart: true,
+	})
+	if !assert.NoError(err) {
+		return
+	}
+
+	config := map[string]interface{}{
+		"Values.bosh.foo": "bar",
+	}
+
+	actual, err := RoundtripNode(manifestSecret, config)
+	if !assert.NoError(err) {
+		return
+	}
+
+	payload := b64.StdEncoding.EncodeToString([]byte("foo: bar"))
+
+	testhelpers.IsYAMLEqualString(assert, `---
+	apiVersion: "v1"
+	data:
+	  deployment-manifest: `+payload+`
+	kind: "Secret"
+	metadata:
+		name: "deployment-manifest"
+		labels:
+			app.kubernetes.io/component: deployment-manifest
+			app.kubernetes.io/instance: MyRelease
+			app.kubernetes.io/managed-by: Tiller
+			app.kubernetes.io/name: MyChart
+			app.kubernetes.io/version: 1.22.333.4444
+			helm.sh/chart: MyChart-42.1_foo
+			skiff-role-name: "deployment-manifest"
+	type: "Opaque"
+	`, actual)
+}

--- a/kube/kube_test.go
+++ b/kube/kube_test.go
@@ -69,6 +69,7 @@ func RenderNode(node helm.Node, config interface{}) ([]byte, error) {
 	functions := sprig.TxtFuncMap()
 	functions["include"] = renderInclude
 	functions["required"] = renderRequired
+	functions["toYaml"] = renderToYaml
 
 	// Note: Replicate helm's behaviour on missing keys.
 	tmpl, err := template.New("").Option("missingkey=zero").Funcs(functions).Parse(string(helmConfig.Bytes()))
@@ -175,6 +176,14 @@ func renderInclude(name string, data interface{}) (string, error) {
 	// first run at this generated a stack overflow.  The fake
 	// simply shows what path/name would have been included.
 	return filepath.Base(name), nil
+}
+
+func renderToYaml(data interface{}) (string, error) {
+	yml, err := yaml.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(yml)), nil
 }
 
 // getBasicConfig returns the built-in configuration

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -461,11 +461,22 @@ func TestStatefulSetVolumesKube(t *testing.T) {
 						-
 							name: shared-volume
 							mountPath: /mnt/shared
+						-
+							name: deployment-manifest
+							mountPath: /opt/fissile/config
+
 					volumes:
 					-
 						name: host-volume
 						hostPath:
 							path: /sys/fs/cgroup
+					-
+						name: deployment-manifest
+						secret:
+							secretName: deployment-manifest
+							items:
+							-	key: deployment-manifest
+								path: deployment-manifest.yml
 			volumeClaimTemplates:
 				-
 					metadata:
@@ -537,11 +548,21 @@ func TestStatefulSetVolumesWithAnnotationKube(t *testing.T) {
 						-
 							name: host-volume
 							mountPath: /sys/fs/cgroup
+						-
+							name: deployment-manifest
+							mountPath: /opt/fissile/config
 					volumes:
 					-
 						name: host-volume
 						hostPath:
 							path: /sys/fs/cgroup
+					-
+						name: deployment-manifest
+						secret:
+							secretName: deployment-manifest
+							items:
+							-	key: deployment-manifest
+								path: deployment-manifest.yml
 			volumeClaimTemplates:
 				-
 					metadata:
@@ -724,12 +745,18 @@ func TestStatefulSetEmptyDirVolumesKube(t *testing.T) {
 						-
 							name: shared-data
 							mountPath: /mnt/shared-data
+						-
+							name: deployment-manifest
+							mountPath: /opt/fissile/config
 					-
 						name: colocated
 						volumeMounts:
 						-
 							name: shared-data
 							mountPath: /mnt/shared-data
+						-
+							name: deployment-manifest
+							mountPath: /opt/fissile/config
 					volumes:
 					-
 						name: host-volume
@@ -738,6 +765,13 @@ func TestStatefulSetEmptyDirVolumesKube(t *testing.T) {
 					-
 						name: shared-data
 						emptyDir: {}
+					-
+						name: deployment-manifest
+						secret:
+							secretName: deployment-manifest
+							items:
+							-	key: deployment-manifest
+								path: deployment-manifest.yml
 			volumeClaimTemplates:
 				-
 					metadata:

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -111,9 +111,15 @@ echo "${KUBE_COMPONENT_INDEX}" > /var/vcap/instance/id
     bash {{ script_path $script }}
 {{ end }}
 
+if [ -e /opt/fissile/config/deployment-manifest.yml ];
+then
+  deployment_manifest_args="--bosh-deployment-manifest /opt/fissile/config/deployment-manifest.yml"
+fi
+
 configgin \
 	--jobs /opt/fissile/job_config.json \
-	--env2conf /opt/fissile/env2conf.yml
+	--env2conf /opt/fissile/env2conf.yml \
+  ${deployment_manifest_args:-}
 
 if [ -e /etc/monitrc ]
 then


### PR DESCRIPTION
The `values.yml` can now embed a BOSH deployment manifest under the `bosh` key, e.g.

```yaml
---
bosh:
  instance_groups:
  - name: nats
    jobs:
    - name: nats
      properties:
        nats:
          port: 4333
env:
  DOMAIN: bosh.io
```

The manifest part will be extracted into a kubernetes secret and mounted in the pods (at `/opt/fissile/config/deployment-manifest.yml`) so that configgin can pick it up.