### PR TITLE
Unconditionally define the deployment-manifest secret

### DIFF
--- a/kube/bosh_deployment_manifest_secret.go
+++ b/kube/bosh_deployment_manifest_secret.go
@@ -9,19 +9,11 @@ func MakeBoshDeploymentManifestSecret(settings ExportSettings) (helm.Node, error
 		value = "{{ .Values.bosh | toYaml | b64enc }}"
 	}
 
-	secret := newKubeConfig(settings, "v1", "Secret", "deployment-manifest", boshDeploymentManifestCondition(settings))
+	secret := newKubeConfig(settings, "v1", "Secret", "deployment-manifest")
 
 	data := helm.NewMapping("deployment-manifest", value)
 	secret.Add("data", data)
 	secret.Add("type", "Opaque")
 
 	return secret, nil
-}
-
-// boshDeploymentManifestCondition creates a block condition checking for an embedded bosh deployment manifest
-func boshDeploymentManifestCondition(settings ExportSettings) helm.NodeModifier {
-	if settings.CreateHelmChart {
-		return helm.Block("if .Values.bosh")
-	}
-	return nil
 }

--- a/kube/bosh_deployment_manifest_secret_test.go
+++ b/kube/bosh_deployment_manifest_secret_test.go
@@ -55,7 +55,7 @@ func TestMakeBoshDeploymentManifestSecretHelm(t *testing.T) {
 		return
 	}
 
-	payload := b64.StdEncoding.EncodeToString([]byte("foo: bar"))
+	payload := b64.StdEncoding.EncodeToString([]byte("foo: bar\ninstance_groups: []"))
 
 	testhelpers.IsYAMLEqualString(assert, `---
 	apiVersion: "v1"

--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -273,13 +273,22 @@ func TestNewDeploymentHelm(t *testing.T) {
 								allowPrivilegeEscalation: false
 								capabilities:
 									add:	~
-							volumeMounts: ~
+							volumeMounts:
+							-	mountPath: /opt/fissile/config
+								name: deployment-manifest
+								readOnly: true
 						dnsPolicy: "ClusterFirst"
 						imagePullSecrets:
 						- name: "registry-credentials"
 						restartPolicy: "Always"
 						terminationGracePeriodSeconds: 600
-						volumes: ~
+						volumes:
+						-	name: deployment-manifest
+							secret:
+								items:
+								-	key: deployment-manifest
+									path: deployment-manifest.yml
+								secretName: deployment-manifest
 		`, actual)
 	})
 }
@@ -477,15 +486,30 @@ func TestNewDeploymentWithEmptyDirVolume(t *testing.T) {
 							-
 								name: shared-data
 								mountPath: /mnt/shared-data
+							-
+								mountPath: /opt/fissile/config
+								name: deployment-manifest
+								readOnly: true
 						-	name: "colocated"
 							volumeMounts:
 							-
 								name: shared-data
 								mountPath: /mnt/shared-data
+							-
+								mountPath: /opt/fissile/config
+								name: deployment-manifest
+								readOnly: true
 						volumes:
 						-
 							name: shared-data
 							emptyDir: {}
+						-
+							name: deployment-manifest
+							secret:
+								items:
+								-	key: deployment-manifest
+									path: deployment-manifest.yml
+								secretName: deployment-manifest
 		`, actual)
 	})
 }

--- a/kube/job_test.go
+++ b/kube/job_test.go
@@ -207,12 +207,21 @@ func TestJobHelm(t *testing.T) {
 							allowPrivilegeEscalation: false
 							capabilities:
 								add:	~
-						volumeMounts: ~
+						volumeMounts:
+						-	mountPath: /opt/fissile/config
+							name: deployment-manifest
+							readOnly: true
 					dnsPolicy: "ClusterFirst"
 					imagePullSecrets:
 					-	name: "registry-credentials"
 					restartPolicy: "OnFailure"
 					terminationGracePeriodSeconds: 600
-					volumes: ~
+					volumes:
+					-	name: deployment-manifest
+						secret:
+							items:
+							-	key: deployment-manifest
+								path: deployment-manifest.yml
+							secretName: deployment-manifest
 	`, actual)
 }

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -275,9 +275,7 @@ func getVolumeMounts(role *model.InstanceGroup, settings ExportSettings) helm.No
 	}
 
 	// Mount the bosh deployment manifest secret if it is available
-	mount = helm.NewMapping("mountPath", "/opt/fissile/config", "name", "deployment-manifest",
-		"readOnly", true)
-	mount.Set(boshDeploymentManifestCondition(settings))
+	mount = helm.NewMapping("mountPath", "/opt/fissile/config", "name", "deployment-manifest", "readOnly", true)
 	mounts = append(mounts, mount)
 
 	return helm.NewNode(mounts)
@@ -327,7 +325,6 @@ func getNonClaimVolumes(role *model.InstanceGroup, settings ExportSettings) helm
 	items := helm.NewList(helm.NewMapping("key", "deployment-manifest", "path", "deployment-manifest.yml"))
 	secret := helm.NewMapping("secretName", "deployment-manifest", "items", items)
 	mount.Add("secret", secret)
-	mount.Set(boshDeploymentManifestCondition(settings))
 	mounts = append(mounts, mount)
 
 	return helm.NewNode(mounts)

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -1822,13 +1822,22 @@ func TestPodPreFlightHelm(t *testing.T) {
 					allowPrivilegeEscalation: false
 					capabilities:
 						add:	~
-				volumeMounts: ~
+				volumeMounts:
+				-	mountPath: /opt/fissile/config
+					name: deployment-manifest
+					readOnly: true
 			dnsPolicy: "ClusterFirst"
 			imagePullSecrets:
 			-	name: "registry-credentials"
 			restartPolicy: "OnFailure"
 			terminationGracePeriodSeconds: 600
-			volumes: ~
+			volumes:
+			-	name: deployment-manifest
+				secret:
+					items:
+					-	key: deployment-manifest
+						path: deployment-manifest.yml
+					secretName: deployment-manifest
 	`, actual)
 }
 
@@ -1931,13 +1940,22 @@ func TestPodPostFlightHelm(t *testing.T) {
 					allowPrivilegeEscalation: false
 					capabilities:
 						add:	~
-				volumeMounts: ~
+				volumeMounts:
+				-	mountPath: /opt/fissile/config
+					name: deployment-manifest
+					readOnly: true
 			dnsPolicy: "ClusterFirst"
 			imagePullSecrets:
 			-	name: "registry-credentials"
 			restartPolicy: "OnFailure"
 			terminationGracePeriodSeconds: 600
-			volumes: ~
+			volumes:
+			-	name: deployment-manifest
+				secret:
+					items:
+					-	key: deployment-manifest
+						path: deployment-manifest.yml
+					secretName: deployment-manifest
 	`, actual)
 }
 
@@ -2052,13 +2070,22 @@ func TestPodMemoryHelmDisabled(t *testing.T) {
 					allowPrivilegeEscalation: false
 					capabilities:
 						add:	~
-				volumeMounts: ~
+				volumeMounts:
+				-	mountPath: /opt/fissile/config
+					name: deployment-manifest
+					readOnly: true
 			dnsPolicy: "ClusterFirst"
 			imagePullSecrets:
 			-	name: "registry-credentials"
 			restartPolicy: "OnFailure"
 			terminationGracePeriodSeconds: 600
-			volumes: ~
+			volumes:
+			-	name: deployment-manifest
+				secret:
+					items:
+					-	key: deployment-manifest
+						path: deployment-manifest.yml
+					secretName: deployment-manifest
 	`, actual)
 }
 
@@ -2136,13 +2163,22 @@ func TestPodMemoryHelmActive(t *testing.T) {
 					allowPrivilegeEscalation: false
 					capabilities:
 						add:	~
-				volumeMounts: ~
+				volumeMounts:
+				-	mountPath: /opt/fissile/config
+					name: deployment-manifest
+					readOnly: true
 			dnsPolicy: "ClusterFirst"
 			imagePullSecrets:
 			-	name: "registry-credentials"
 			restartPolicy: "OnFailure"
 			terminationGracePeriodSeconds: 600
-			volumes: ~
+			volumes:
+			-	name: deployment-manifest
+				secret:
+					items:
+					-	key: deployment-manifest
+						path: deployment-manifest.yml
+					secretName: deployment-manifest
 	`, actual)
 }
 
@@ -2255,13 +2291,22 @@ func TestPodCPUHelmDisabled(t *testing.T) {
 					allowPrivilegeEscalation: false
 					capabilities:
 						add:	~
-				volumeMounts: ~
+				volumeMounts:
+				-	mountPath: /opt/fissile/config
+					name: deployment-manifest
+					readOnly: true
 			dnsPolicy: "ClusterFirst"
 			imagePullSecrets:
 			-	name: "registry-credentials"
 			restartPolicy: "OnFailure"
 			terminationGracePeriodSeconds: 600
-			volumes: ~
+			volumes:
+			-	name: deployment-manifest
+				secret:
+					items:
+					-	key: deployment-manifest
+						path: deployment-manifest.yml
+					secretName: deployment-manifest
 	`, actual)
 }
 
@@ -2339,13 +2384,22 @@ func TestPodCPUHelmActive(t *testing.T) {
 					allowPrivilegeEscalation: false
 					capabilities:
 						add:	~
-				volumeMounts: ~
+				volumeMounts:
+				-	mountPath: /opt/fissile/config
+					name: deployment-manifest
+					readOnly: true
 			dnsPolicy: "ClusterFirst"
 			imagePullSecrets:
 			-	name: "registry-credentials"
 			restartPolicy: "OnFailure"
 			terminationGracePeriodSeconds: 600
-			volumes: ~
+			volumes:
+			-	name: deployment-manifest
+				secret:
+					items:
+					-	key: deployment-manifest
+						path: deployment-manifest.yml
+					secretName: deployment-manifest
 	`, actual)
 }
 
@@ -2806,7 +2860,13 @@ func TestPodVolumeTypeEmptyDir(t *testing.T) {
 	testhelpers.IsYAMLEqualString(assert, `---
 		-	name: "shared-data"
 			emptyDir: {}
-`, actual)
+		-	name: deployment-manifest
+			secret:
+				items:
+				-	key: deployment-manifest
+					path: deployment-manifest.yml
+				secretName: deployment-manifest
+	`, actual)
 
 	// Check each role for its volume mount
 	for _, roleName := range []string{"main-role", "to-be-colocated"} {
@@ -2819,8 +2879,11 @@ func TestPodVolumeTypeEmptyDir(t *testing.T) {
 			return
 		}
 		testhelpers.IsYAMLEqualString(assert, `---
-			- mountPath: "/var/vcap/store"
-			  name: "shared-data"
-`, actual)
+			-	mountPath: "/var/vcap/store"
+				name: "shared-data"
+			-	mountPath: /opt/fissile/config
+				name: deployment-manifest
+				readOnly: true
+		`, actual)
 	}
 }

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -651,12 +651,23 @@ func TestStatefulSetVolumesHelm(t *testing.T) {
 						-
 							name: shared-volume
 							mountPath: /mnt/shared
+						-
+							mountPath: /opt/fissile/config
+							name: deployment-manifest
+							readOnly: true
 					volumes:
 					-
 						name: host-volume
 						hostPath:
 							path: /sys/fs/cgroup
 							type: Directory
+					-
+						name: deployment-manifest
+						secret:
+							items:
+							-	key: deployment-manifest
+								path: deployment-manifest.yml
+							secretName: deployment-manifest
 			volumeClaimTemplates:
 				-
 					metadata:
@@ -700,7 +711,8 @@ func TestStatefulSetVolumesHelm(t *testing.T) {
 	for _, k := range []string{"spec", "template", "spec", "volumes"} {
 		volumes = volumes.(map[interface{}]interface{})[k]
 	}
-	assert.Empty(volumes, "Hostpath volumes should not be available")
+	assert.Len(volumes, 1, "Hostpath volumes should not be available")
+	assert.Equal("deployment-manifest", volumes.([]interface{})[0].(map[interface{}]interface{})["name"])
 }
 
 func TestStatefulSetEmptyDirVolumesKube(t *testing.T) {

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -95,6 +95,7 @@ func MakeBasicValues() *helm.Mapping {
 				"requests", helm.NewNode(false, helm.Comment("Flag to activate cpu requests")),
 				"limits", helm.NewNode(false, helm.Comment("Flag to activate cpu limits")),
 			), helm.Comment("Global CPU configuration"))),
+		"bosh", helm.NewMapping("instance_groups", helm.NewList()),
 		"env", helm.NewMapping(),
 		"sizing", helm.NewMapping(),
 		"secrets", helm.NewMapping(),

--- a/kube/values.go
+++ b/kube/values.go
@@ -187,13 +187,14 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 		registry = "docker.io"
 	}
 	// Override registry settings
-	values.Get("kube").(*helm.Mapping).Add("registry", helm.NewMapping(
+	kube := values.Get("kube").(*helm.Mapping)
+	kube.Add("registry", helm.NewMapping(
 		"hostname", registry,
 		"username", settings.Username,
 		"password", settings.Password))
-	values.Get("kube").(*helm.Mapping).Add("organization", settings.Organization)
+	kube.Add("organization", settings.Organization)
 	if settings.AuthType != "" {
-		values.Get("kube").(*helm.Mapping).Add("auth", settings.AuthType)
+		kube.Add("auth", settings.AuthType)
 	}
 
 	return values, nil

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -125,15 +125,10 @@ done
     bash {{ script_path $script }}
 {{ end }}
 
-if [ -e /opt/fissile/config/deployment-manifest.yml ];
-then
-  deployment_manifest_args="--bosh-deployment-manifest /opt/fissile/config/deployment-manifest.yml"
-fi
-
 configgin \
 	--jobs /opt/fissile/job_config.json \
 	--env2conf /opt/fissile/env2conf.yml \
-  ${deployment_manifest_args:-}
+	--bosh-deployment-manifest /opt/fissile/config/deployment-manifest.yml
 
 if [ -e /etc/monitrc ]
 then


### PR DESCRIPTION
The generated kube config files reference them unconditionally and will therefore fail to start if this object isn't available at runtime.

Configgin expects that `bosh.instance_groups` exists (and is an array), so add an empty list as the default value in `values.yaml`.