### PR TITLE
model: expose service_name in config_spec.json (for jobs)

### DIFF
--- a/model/job.go
+++ b/model/job.go
@@ -17,10 +17,11 @@ import (
 
 // jobLinkInfo describes a BOSH link provider or consumer
 type jobLinkInfo struct {
-	Name     string `json:"-" yaml:"-"`
-	Type     string `json:"-" yaml:"-"`
-	RoleName string `json:"role" yaml:"-"`
-	JobName  string `json:"job" yaml:"-"`
+	Name        string `json:"-" yaml:"-"`
+	Type        string `json:"-" yaml:"-"`
+	RoleName    string `json:"role" yaml:"-"`
+	JobName     string `json:"job" yaml:"-"`
+	ServiceName string `json:"service_name" yaml:"-"`
 }
 
 // jobProvidesInfo describes a BOSH link provider

--- a/model/job_reference_test.go
+++ b/model/job_reference_test.go
@@ -72,6 +72,7 @@ func TestWriteConfigs(t *testing.T) {
 	json, err := role.JobReferences[0].WriteConfigs(role, tempFile.Name(), tempFile.Name())
 	assert.NoError(err)
 
+	// `service_name` is empty because we never resolved links
 	assert.JSONEq(`
 	{
 		"job": {
@@ -90,7 +91,8 @@ func TestWriteConfigs(t *testing.T) {
 		"consumes": {
 			"serious": {
 				"role": "dummy role",
-				"job": "silly job"
+				"job": "silly job",
+				"service_name": ""
 			}
 		},
 		"exported_properties": [

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -969,6 +969,11 @@ func TestRoleResolveLinksMultipleProvider(t *testing.T) {
 								Alias: "unique-alias",
 							},
 						},
+						ContainerProperties: JobContainerProperties{
+							BoshContainerization: JobBoshContainerization{
+								ServiceName: "job-1-service",
+							},
+						},
 					},
 					{Job: job2},
 				},
@@ -1019,10 +1024,11 @@ func TestRoleResolveLinksMultipleProvider(t *testing.T) {
 	if assert.Contains(consumes, "job-1-provider-1", "failed to find role by type") {
 		assert.Equal(jobConsumesInfo{
 			jobLinkInfo: jobLinkInfo{
-				Name:     "job-1-provider-1",
-				Type:     "link-1",
-				RoleName: "role-1",
-				JobName:  "job-1",
+				Name:        "job-1-provider-1",
+				Type:        "link-1",
+				RoleName:    "role-1",
+				JobName:     "job-1",
+				ServiceName: "job-1-service",
 			},
 		}, consumes["job-1-provider-1"], "found incorrect role by type")
 	}
@@ -1033,10 +1039,11 @@ func TestRoleResolveLinksMultipleProvider(t *testing.T) {
 	if assert.Contains(consumes, "job-3-provider-3", "did not find explicitly named provider") {
 		assert.Equal(jobConsumesInfo{
 			jobLinkInfo: jobLinkInfo{
-				Name:     "job-3-provider-3",
-				Type:     "link-4",
-				RoleName: "role-2",
-				JobName:  "job-3",
+				Name:        "job-3-provider-3",
+				Type:        "link-4",
+				RoleName:    "role-2",
+				JobName:     "job-3",
+				ServiceName: "role-2-job-3",
 			},
 		}, consumes["job-3-provider-3"], "did not find explicitly named provider")
 	}
@@ -1044,10 +1051,11 @@ func TestRoleResolveLinksMultipleProvider(t *testing.T) {
 	if assert.Contains(consumes, "actual-consumer-name", "did not resolve consumer with alias") {
 		assert.Equal(jobConsumesInfo{
 			jobLinkInfo: jobLinkInfo{
-				Name:     "job-1-provider-3",
-				Type:     "link-5",
-				RoleName: "role-1",
-				JobName:  "job-1",
+				Name:        "job-1-provider-3",
+				Type:        "link-5",
+				RoleName:    "role-1",
+				JobName:     "job-1",
+				ServiceName: "job-1-service",
 			},
 		}, consumes["actual-consumer-name"], "resolved to incorrect provider for alias")
 	}


### PR DESCRIPTION
This is so configgin can use it to construct the correct host name to contact (when resolving BOSH links).