### PR TITLE
 kube/pod.go: force allowPrivilegeEscalation if privileged

### DIFF
--- a/kube/pod.go
+++ b/kube/pod.go
@@ -516,7 +516,6 @@ func getSecurityContext(role *model.InstanceGroup, createHelmChart bool) helm.No
 
 	sc := helm.NewMapping()
 	allowPrivileged := role.PodSecurityPolicy() == model.PodSecurityPolicyPrivileged
-	sc.Add("allowPrivilegeEscalation", allowPrivileged)
 
 	capabilities := role.Run.Capabilities
 	if createHelmChart {
@@ -536,10 +535,17 @@ func getSecurityContext(role *model.InstanceGroup, createHelmChart bool) helm.No
 		// Complete the context, with conditional privileged mode
 		sc.Add("privileged", helm.NewNode(true, helm.Block(hasAll)))
 		sc.Add("capabilities", cla)
+		if allowPrivileged {
+			sc.Add("allowPrivilegeEscalation", allowPrivileged)
+		} else {
+			// We ned to allow privilege escalation if if want privileged mode
+			sc.Add("allowPrivilegeEscalation", fmt.Sprintf("{{ %s }} true {{ else }} false {{ end }}", hasAll))
+		}
 	} else {
 		if len(capabilities) > 0 {
 			sc.Add("capabilities", helm.NewMapping("add", helm.NewNode(capabilities)))
 		}
+		sc.Add("allowPrivilegeEscalation", allowPrivileged)
 	}
 
 	return sc

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -539,7 +539,7 @@ func getSecurityContext(role *model.InstanceGroup, createHelmChart bool) helm.No
 			sc.Add("allowPrivilegeEscalation", allowPrivileged)
 		} else {
 			// We ned to allow privilege escalation if if want privileged mode
-			sc.Add("allowPrivilegeEscalation", fmt.Sprintf("{{ %s }} true {{ else }} false {{ end }}", hasAll))
+			sc.Add("allowPrivilegeEscalation", fmt.Sprintf("{{ %s -}} true {{- else -}} false {{- end }}", hasAll))
 		}
 	} else {
 		if len(capabilities) > 0 {

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -2465,7 +2465,8 @@ func TestGetSecurityContextCapList(t *testing.T) {
 				return
 			}
 			testhelpers.IsYAMLEqualString(assert, `---
-				allowPrivilegeEscalation: false
+				# privileged: true implies allowPrivilegeEscalation
+				allowPrivilegeEscalation: true
 				privileged: true
 			`, actual)
 		})
@@ -2552,7 +2553,8 @@ func TestGetSecurityContextNil(t *testing.T) {
 				return
 			}
 			testhelpers.IsYAMLEqualString(assert, `---
-				allowPrivilegeEscalation: false
+				# privileged: true implies allowPrivilegeEscalation
+				allowPrivilegeEscalation: true
 				privileged: true
 			`, actual)
 		})


### PR DESCRIPTION
Otherwise kube will reject the pod with:

  create Pod … in StatefulSet … failed error: Pod … is invalid:
   … cannot set `allowPrivilegeEscalation` to false and
   `privileged` to true
