### PR TITLE
Don't include "environment" type variable without default value in pod spec

### DIFF
--- a/kube/pod.go
+++ b/kube/pod.go
@@ -477,8 +477,11 @@ func getEnvVarsFromConfigs(configs model.Variables, settings ExportSettings) (he
 				`{{%s | toJson | quote}}{{else}}{{%s | quote}}{{end}}{{else}}%s{{end}}`
 			stringifiedValue = fmt.Sprintf(tmpl, name, name, name, name, required)
 		} else {
-			_, stringifiedValue = config.Value(settings.Defaults)
-
+			var ok bool
+			ok, stringifiedValue = config.Value(settings.Defaults)
+			if !ok && config.CVOptions.Type == model.CVTypeEnv {
+				continue
+			}
 		}
 		env = append(env, helm.NewMapping("name", config.Name, "value", stringifiedValue))
 	}

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -959,6 +959,12 @@ func TestPodGetEnvVarsFromConfigNonSecretKube(t *testing.T) {
 			&model.VariableDefinition{
 				Name: "SOMETHING",
 			},
+			&model.VariableDefinition{
+				Name: "HOSTNAME",
+				CVOptions: model.CVOptions{
+					Type: model.CVTypeEnv,
+				},
+			},
 		}, settings)
 
 		actual, err := RoundtripNode(ev, nil)


### PR DESCRIPTION
This is primarily aimed at `HOSTNAME`, which should not be set to the empty string, as that prevents it from being setup by the host container.