### PR TITLE
run.sh: Do the move dance only when BPM is present; chown, too

### DIFF
--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -110,11 +110,15 @@ ln -s /var/vcap/sys /var/vcap/data/sys
 
 # Move packages from /var/vcap/packages-src to /var/vcap/packages
 # This is necessary because the ../packages-src symlink does not resolve inside bpm containers
-for pkg in /var/vcap/packages/*; do
-    target=$(readlink -f ${pkg})
-    rm ${pkg}
-    mv ${target} ${pkg}
-done
+if test -d /var/vcap/packages/bpm ; then
+    # In a BPM world, /var/vcap/packages isn't mapped into the chroot
+    for pkg in /var/vcap/packages/*; do
+        target=$(readlink -f "${pkg}")
+        rm "${pkg}"
+        mv "${target}" "${pkg}"
+        chown -R vcap:vcap "${pkg}" # Work around strange permission issues
+    done
+fi
 
 # Run custom environment scripts (that are sourced)
 {{ range $script := .instance_group.EnvironScripts }}


### PR DESCRIPTION
There are odd permissions issues on Jenkins sometimes with the packages directories.  They seem to be resolved by changing the owner of the files so that `vcap` can read them.

This is a workaround that should be removed once we drop the packages layer.
