### PR TITLE
resolver: don't crash on invalid job

### DIFF
--- a/model/resolver/resolver.go
+++ b/model/resolver/resolver.go
@@ -165,7 +165,9 @@ func (r *Resolver) ResolveRoleManifest() error {
 
 		if grapher != nil {
 			for _, jobReference := range instanceGroup.JobReferences {
-				grapher.GraphNode(jobReference.Job.Fingerprint, map[string]string{"label": "job/" + jobReference.Job.Name})
+				if jobReference.Job != nil {
+					grapher.GraphNode(jobReference.Job.Fingerprint, map[string]string{"label": "job/" + jobReference.Job.Name})
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When a job can't be resolved (because of a busted role manifest), `validateInstanceGroup` will return an error.  But since we don't immediately abort in that case when graphing, we end up crashing trying to dereference the nil job.