### PR TITLE
support diffing final releases.

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -724,14 +724,16 @@ func (f *Fissile) GetDiffConfigurationBases(releasePaths []string, cacheDir stri
 	if len(releasePaths) != 2 {
 		return nil, fmt.Errorf("expected two release paths, got %d", len(releasePaths))
 	}
-	defaultValues := []string{}
-	releases, err := releaseresolver.LoadReleasesFromDisk(model.ReleaseOptions{
-		ReleasePaths:    releasePaths,
-		ReleaseNames:    defaultValues,
-		ReleaseVersions: defaultValues,
-		BOSHCacheDir:    cacheDir})
+	resolver := releaseresolver.NewReleaseResolver(cacheDir)
+	releases, err := resolver.Load(
+		model.ReleaseOptions{
+			ReleasePaths:    releasePaths,
+			ReleaseNames:    []string{},
+			ReleaseVersions: []string{},
+			BOSHCacheDir:    cacheDir},
+		nil)
 	if err != nil {
-		return nil, fmt.Errorf("dev config diff: error loading release information: %s", err)
+		return nil, fmt.Errorf("config diff: error loading release information: %s", err)
 	}
 	return getDiffsFromReleases(releases)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -363,6 +363,10 @@ func absolutePaths(paths ...*string) error {
 }
 
 func absolutePath(path string) (string, error) {
+	if strings.Contains(path, "://") {
+		// Special case URLs
+		return path, nil
+	}
 	path, err := filepath.Abs(path)
 	if err != nil {
 		return "", fmt.Errorf("Error getting absolute path for path %s: %v", path, err)

--- a/model/loader/loader.go
+++ b/model/loader/loader.go
@@ -4,6 +4,8 @@ package loader
 // resolvers we want to keep `dep ensure` small
 
 import (
+	"path/filepath"
+
 	"code.cloudfoundry.org/fissile/model"
 	"code.cloudfoundry.org/fissile/model/releaseresolver"
 	"code.cloudfoundry.org/fissile/model/resolver"
@@ -17,6 +19,6 @@ func LoadRoleManifest(manifestFilePath string, options model.LoadRoleManifestOpt
 		return nil, err
 	}
 
-	r := releaseresolver.NewReleaseResolver(manifestFilePath)
+	r := releaseresolver.NewReleaseResolver(filepath.Dir(manifestFilePath))
 	return resolver.NewResolver(roleManifest, r, options).Resolve()
 }

--- a/model/releaseresolver/load_releases.go
+++ b/model/releaseresolver/load_releases.go
@@ -1,9 +1,14 @@
 package releaseresolver
 
 import (
+	"archive/tar"
+	"crypto/sha1"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"sync"
 
@@ -13,127 +18,50 @@ import (
 	"github.com/mholt/archiver"
 	"github.com/vbauerster/mpb"
 	"github.com/vbauerster/mpb/decor"
+	"gopkg.in/yaml.v2"
 )
 
-//LoadReleasesFromDisk loads information about BOSH releases
-func LoadReleasesFromDisk(options model.ReleaseOptions) ([]*model.Release, error) {
-	releases := make([]*model.Release, len(options.ReleasePaths))
-	for idx, releasePath := range options.ReleasePaths {
-		var releaseName, releaseVersion string
-		if len(options.ReleaseNames) != 0 {
-			releaseName = options.ReleaseNames[idx]
-		}
-		if len(options.ReleaseVersions) != 0 {
-			releaseVersion = options.ReleaseVersions[idx]
-		}
-		var release *model.Release
-		var err error
-		if _, err = isFinalReleasePath(releasePath); err == nil {
-			// For final releases, only can use release name and version defined in release.MF, cannot specify them through flags.
-			release, err = model.NewFinalRelease(releasePath)
-			if err != nil {
-				return nil, fmt.Errorf("Error loading final release information: %s", err.Error())
-			}
-		} else {
-			release, err = model.NewDevRelease(releasePath, releaseName, releaseVersion, options.BOSHCacheDir)
-			if err != nil {
-				return nil, fmt.Errorf("Error loading dev release information: %s", err.Error())
-			}
-		}
-		releases[idx] = release
-	}
-	return releases, nil
-}
-
-func isFinalReleasePath(releasePath string) (bool, error) {
-	if err := util.ValidatePath(releasePath, true, "release directory"); err != nil {
-		return false, err
-	}
-	if err := util.ValidatePath(filepath.Join(releasePath, "release.MF"), false, "release 'release.MF' file"); err != nil {
-		return false, err
-	}
-	if err := util.ValidatePath(filepath.Join(releasePath, "dev_releases"), true, "release 'dev_releases' file"); err == nil {
-		return false, err
-	}
-	if err := util.ValidatePath(filepath.Join(releasePath, "jobs"), true, "release 'jobs' directory"); err != nil {
-		return false, err
-	}
-	if err := util.ValidatePath(filepath.Join(releasePath, "packages"), true, "release 'packages' directory"); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-// downloadReleaseReferences downloads/builds and loads releases referenced in the
-// manifest
-func downloadReleaseReferences(releaseRefs []*model.ReleaseRef, manifestPath string) ([]*model.Release, error) {
+// loadReleases loads information about BOSH releases, whether locally or from the internet
+func loadReleases(releaseRefs []*model.ReleaseRef, cacheDir string) ([]*model.Release, error) {
 	releases := []*model.Release{}
 
+	// Download releases as needed
 	var allErrs error
 	var wg sync.WaitGroup
 	progress := mpb.New(mpb.WithWaitGroup(&wg))
 
-	// go through each referenced release
 	for _, releaseRef := range releaseRefs {
-		wg.Add(1)
-
-		go func(releaseRef *model.ReleaseRef) {
-			defer wg.Done()
-			_, err := url.ParseRequestURI(releaseRef.URL)
-			if err != nil {
-				// this is a local release that we need to build/load
-				// TODO: support this
-				allErrs = multierror.Append(allErrs, fmt.Errorf("Dev release %s is not supported as manifest references", releaseRef.Name))
-				return
-			}
+		if isReleaseRefRemote(releaseRef) {
 			// this is a final release that we need to download
-			manifestDir := filepath.Dir(manifestPath)
-			finalReleasesWorkDir := filepath.Join(manifestDir, ".final_releases")
-			finalReleaseTarballPath := filepath.Join(
-				finalReleasesWorkDir,
-				fmt.Sprintf("%s-%s-%s.tgz", releaseRef.Name, releaseRef.Version, releaseRef.SHA1))
-			finalReleaseUnpackedPath := filepath.Join(
-				finalReleasesWorkDir,
-				fmt.Sprintf("%s-%s-%s", releaseRef.Name, releaseRef.Version, releaseRef.SHA1))
+			wg.Add(1)
 
-			if _, err := os.Stat(filepath.Join(finalReleaseUnpackedPath, "release.MF")); err != nil && os.IsNotExist(err) {
-				err = os.MkdirAll(finalReleaseUnpackedPath, 0700)
+			go func(releaseRef *model.ReleaseRef) {
+				err := downloadReleaseArchive(releaseRef, cacheDir, progress)
 				if err != nil {
 					allErrs = multierror.Append(allErrs, err)
-					return
 				}
-
-				// Show download progress
-				bar := progress.AddBar(
-					100,
-					mpb.BarRemoveOnComplete(),
-					mpb.PrependDecorators(
-						decor.Name(releaseRef.Name, decor.WCSyncSpaceR),
-						decor.Percentage(decor.WCSyncWidth),
-					))
-				lastPercentage := 0
-
-				// download the release in a directory next to the role manifest
-				err = util.DownloadFile(finalReleaseTarballPath, releaseRef.URL, func(percentage int) {
-					bar.IncrBy(percentage - lastPercentage)
-					lastPercentage = percentage
-				})
-				if err != nil {
-					allErrs = multierror.Append(allErrs, err)
-					return
-				}
-				defer func() {
-					os.Remove(finalReleaseTarballPath)
+				wg.Done()
+			}(releaseRef)
+		} else {
+			// This is a local release; check for archives
+			pathInfo, err := os.Stat(releaseRef.URL)
+			if err != nil {
+				allErrs = multierror.Append(allErrs, err)
+			} else if !pathInfo.IsDir() {
+				wg.Add(1)
+				go func() {
+					// This is a file, unpack it
+					if releaseRef.SHA1 == "" {
+						// Calculate the hash
+					}
+					err := unpackReleaseArchive(releaseRef, releaseRef.URL, cacheDir)
+					if err != nil {
+						allErrs = multierror.Append(allErrs, err)
+					}
+					wg.Done()
 				}()
-
-				// unpack
-				err = archiver.TarGz.Open(finalReleaseTarballPath, finalReleaseUnpackedPath)
-				if err != nil {
-					allErrs = multierror.Append(allErrs, err)
-					return
-				}
 			}
-		}(releaseRef)
+		}
 	}
 
 	wg.Wait()
@@ -141,20 +69,222 @@ func downloadReleaseReferences(releaseRefs []*model.ReleaseRef, manifestPath str
 	// Now that all releases have been downloaded and unpacked,
 	// add them to the collection
 	for _, releaseRef := range releaseRefs {
-		manifestDir := filepath.Dir(manifestPath)
-		finalReleasesWorkDir := filepath.Join(manifestDir, ".final_releases")
-		finalReleaseUnpackedPath := filepath.Join(
-			finalReleasesWorkDir,
-			fmt.Sprintf("%s-%s-%s", releaseRef.Name, releaseRef.Version, releaseRef.SHA1))
+		var release *model.Release
+		var err error
+		if isReleaseRefRemote(releaseRef) {
+			finalReleaseUnpackedPath := getFinalReleaseUnpackedPath(releaseRef, cacheDir)
 
-		// create a release object and add it to the collection
-		release, err := model.NewFinalRelease(finalReleaseUnpackedPath)
+			// create a release object and add it to the collection
+			release, err = model.NewFinalRelease(finalReleaseUnpackedPath)
 
-		if err != nil {
-			allErrs = multierror.Append(allErrs, err)
+			if err != nil {
+				allErrs = multierror.Append(allErrs, err)
+			}
+		} else {
+			err = fixupLocalRelease(releaseRef, cacheDir)
+			if err != nil {
+				allErrs = multierror.Append(allErrs, err)
+				continue
+			}
+			if err = checkFinalReleasePath(releaseRef.URL); err == nil {
+				// For final releases, only can use release name and version defined in release.MF, cannot specify them through flags.
+				release, err = model.NewFinalRelease(releaseRef.URL)
+				if err != nil {
+					return nil, fmt.Errorf("Error loading final release information: %s", err.Error())
+				}
+			} else {
+				// For dev releases, use the information given
+				release, err = model.NewDevRelease(
+					releaseRef.URL,
+					releaseRef.Name,
+					releaseRef.Version,
+					cacheDir)
+				if err != nil {
+					return nil, fmt.Errorf("Error loading dev release information: %s", err.Error())
+				}
+			}
 		}
 		releases = append(releases, release)
 	}
 
 	return releases, allErrs
+}
+
+// isReleaseRefRemote returns true if the given ReleaseRef looks like a remote URL
+func isReleaseRefRemote(releaseRef *model.ReleaseRef) bool {
+	if releaseRef.URL == "" {
+		return false
+	}
+	u, err := url.ParseRequestURI(releaseRef.URL)
+	return err == nil && u.IsAbs()
+}
+
+// checkFinalReleasePath checks to see if a given path is an unpacked final release; returns nil on success
+func checkFinalReleasePath(releasePath string) error {
+	if err := util.ValidatePath(releasePath, true, "release directory"); err != nil {
+		return err
+	}
+	if err := util.ValidatePath(filepath.Join(releasePath, "release.MF"), false, "release 'release.MF' file"); err != nil {
+		return err
+	}
+	if err := util.ValidatePath(filepath.Join(releasePath, "dev_releases"), true, "release 'dev_releases' file"); err == nil {
+		return err
+	}
+	if err := util.ValidatePath(filepath.Join(releasePath, "jobs"), true, "release 'jobs' directory"); err != nil {
+		return err
+	}
+	if err := util.ValidatePath(filepath.Join(releasePath, "packages"), true, "release 'packages' directory"); err != nil {
+		return err
+	}
+
+	err := error(nil)
+	return err
+}
+
+func getFinalReleaseUnpackedPath(releaseRef *model.ReleaseRef, cacheDir string) string {
+	return filepath.Join(
+		cacheDir,
+		".final_releases",
+		fmt.Sprintf("%s-%s-%s", releaseRef.Name, releaseRef.Version, releaseRef.SHA1))
+}
+
+// downloadReleaseArchive downloads and unpacks a release reference
+func downloadReleaseArchive(releaseRef *model.ReleaseRef, cacheDir string, progress *mpb.Progress) error {
+	finalReleasesWorkDir := filepath.Join(cacheDir, ".final_releases")
+	finalReleaseTarballPath := filepath.Join(
+		finalReleasesWorkDir,
+		fmt.Sprintf("%s-%s-%s.tgz", releaseRef.Name, releaseRef.Version, releaseRef.SHA1))
+
+	usingTempFile := false
+	var finalReleaseUnpackedPath string
+	if releaseRef.Name == "" || releaseRef.Version == "" || releaseRef.SHA1 == "" {
+		usingTempFile = true
+		tempFile, err := ioutil.TempFile(finalReleasesWorkDir, "download-temp-*.tgz")
+		if err != nil {
+			return err
+		}
+		finalReleaseTarballPath = tempFile.Name()
+		_ = tempFile.Close()
+		defer os.Remove(finalReleaseTarballPath)
+
+		finalReleaseUnpackedPath, err = ioutil.TempDir(finalReleasesWorkDir, "unpack-temp-")
+		if err != nil {
+			return err
+		}
+		defer os.RemoveAll(finalReleaseUnpackedPath)
+	} else {
+		finalReleaseUnpackedPath = getFinalReleaseUnpackedPath(releaseRef, cacheDir)
+
+		manifestPath := filepath.Join(finalReleaseUnpackedPath, "release.MF")
+		if _, err := os.Stat(manifestPath); err == nil || !os.IsNotExist(err) {
+			// Already unpacked successfully
+			return err
+		}
+
+		err := os.MkdirAll(finalReleaseUnpackedPath, 0700)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Show download progress
+	bar := progress.AddBar(
+		100,
+		mpb.BarRemoveOnComplete(),
+		mpb.PrependDecorators(
+			decor.Name(releaseRef.Name, decor.WCSyncSpaceR),
+			decor.Percentage(decor.WCSyncWidth),
+		))
+	lastPercentage := 0
+
+	// download the release in a subdirectory of the cacheDir
+	err := util.DownloadFile(finalReleaseTarballPath, releaseRef.URL, func(percentage int) {
+		bar.IncrBy(percentage - lastPercentage)
+		lastPercentage = percentage
+	})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		os.Remove(finalReleaseTarballPath)
+	}()
+
+	// Fix up release info if it's missing
+	if usingTempFile {
+		releaseRef.URL = finalReleaseTarballPath
+		err = fixupLocalRelease(releaseRef, cacheDir)
+		if err != nil {
+			return err
+		}
+	}
+
+	// unpack
+	err = unpackReleaseArchive(releaseRef, finalReleaseTarballPath, cacheDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// unpackReleaseArchive unpacks a final release tarball
+func unpackReleaseArchive(releaseRef *model.ReleaseRef, tarballPath, cacheDir string) error {
+	finalReleaseUnpackedPath := getFinalReleaseUnpackedPath(releaseRef, cacheDir)
+	manifestPath := filepath.Join(finalReleaseUnpackedPath, "release.MF")
+
+	err := archiver.TarGz.Open(tarballPath, finalReleaseUnpackedPath)
+	if err != nil {
+		// Delete the manifest so we retry downloading next time; ignore any errors
+		_ = os.Remove(manifestPath)
+		return err
+	}
+	return nil
+}
+
+// fixupLocalRelease will unpack local releases as necessary
+func fixupLocalRelease(releaseRef *model.ReleaseRef, cacheDir string) error {
+	if isReleaseRefRemote(releaseRef) {
+		panic(fmt.Sprintf("Release %+v is remote", releaseRef))
+	}
+	pathInfo, err := os.Stat(releaseRef.URL)
+	if err != nil {
+		return err
+	}
+	if pathInfo.IsDir() {
+		// Already unpacked (possibly dev) release
+		return nil
+	}
+
+	// Read the release information from the archive
+	reader, err := os.Open(releaseRef.URL)
+	if err != nil {
+		return err
+	}
+	util.TargzIterate(releaseRef.URL, reader, func(reader *tar.Reader, header *tar.Header) error {
+		if path.Clean(header.Name) != "release.MF" {
+			return nil
+		}
+		err := yaml.NewDecoder(reader).Decode(releaseRef)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	_, err = reader.Seek(0, os.SEEK_SET)
+	if err != nil {
+		return err
+	}
+	hasher := sha1.New()
+	_, err = io.Copy(hasher, reader)
+	if err != nil {
+		return err
+	}
+	releaseRef.SHA1 = fmt.Sprintf("%x", hasher.Sum(nil))
+
+	err = unpackReleaseArchive(releaseRef, releaseRef.URL, cacheDir)
+	if err != nil {
+		return err
+	}
+	releaseRef.URL = getFinalReleaseUnpackedPath(releaseRef, cacheDir)
+	return checkFinalReleasePath(releaseRef.URL)
 }

--- a/model/resolver/resolve_role_manifest_test.go
+++ b/model/resolver/resolve_role_manifest_test.go
@@ -38,7 +38,7 @@ func setRoleManifest(roleManifestPath string, manifestContent []byte, releases R
 func resolveRoleManifest(roleManifest *RoleManifest, roleManifestPath string, allowMissingScripts bool) error {
 	r := resolver.NewResolver(
 		roleManifest,
-		releaseresolver.NewReleaseResolver(roleManifestPath),
+		releaseresolver.NewReleaseResolver(filepath.Dir(roleManifestPath)),
 		LoadRoleManifestOptions{
 			Grapher:           nil,
 			ValidationOptions: RoleManifestValidationOptions{AllowMissingScripts: allowMissingScripts},
@@ -53,13 +53,15 @@ func TestRoleManifestTagList(t *testing.T) {
 	require.NoError(t, err)
 
 	torReleasePath := filepath.Join(workDir, "../../test-assets/tor-boshrelease")
-	releases, err := releaseresolver.LoadReleasesFromDisk(
+	resolver := releaseresolver.NewReleaseResolver(filepath.Join(workDir, "../../test-assets/bosh-cache"))
+	releases, err := resolver.Load(
 		ReleaseOptions{
 			ReleasePaths:    []string{torReleasePath},
 			ReleaseNames:    []string{},
 			ReleaseVersions: []string{},
 			BOSHCacheDir:    filepath.Join(workDir, "../../test-assets/bosh-cache"),
-		})
+		},
+		nil)
 	require.NoError(t, err, "Error reading BOSH release")
 
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/tor-good.yml")


### PR DESCRIPTION
- release-resolver: unify loading via releaseRefs
- release-resolver: use temporary files for URLs
- release-resolver: look up release info from final release tarballs
- cmd: skip normalizing release paths that look like URLs

Fixes #455.

I don't like this much yet; there's a bit with a hard `://` check that smells a bit. It's also a lot of change in code I'm not all that familiar with.

:bug:Bug: this seems to accidentally move the final releases dir, which means we'll need to re-download things again.