### PR TITLE
Implement ingress support in fissile.

### DIFF
--- a/kube/service.go
+++ b/kube/service.go
@@ -213,7 +213,7 @@ func newService(role *model.InstanceGroup, job *model.JobReference, serviceType 
 	}
 	if serviceType == newServiceTypePublic {
 		if settings.CreateHelmChart {
-			spec.Add("externalIPs", "{{ .Values.kube.external_ips | toJson }}", helm.Block("if or (not .Values.services.loadbalanced) .Values.services.ingress"))
+			spec.Add("externalIPs", "{{ .Values.kube.external_ips | toJson }}", helm.Block("if not (or .Values.services.loadbalanced .Values.services.ingress)"))
 			spec.Add("type", "LoadBalancer", helm.Block("if and .Values.services.loadbalanced (not .Values.services.ingress)"))
 		} else {
 			spec.Add("externalIPs", []string{"192.168.77.77"})

--- a/kube/service.go
+++ b/kube/service.go
@@ -214,7 +214,7 @@ func newService(role *model.InstanceGroup, job *model.JobReference, serviceType 
 	if serviceType == newServiceTypePublic {
 		if settings.CreateHelmChart {
 			spec.Add("externalIPs", "{{ .Values.kube.external_ips | toJson }}", helm.Block("if not (or .Values.services.loadbalanced .Values.services.ingress)"))
-			spec.Add("type", "LoadBalancer", helm.Block("if and .Values.services.loadbalanced (not .Values.services.ingress)"))
+			spec.Add("type", "LoadBalancer", helm.Block("if .Values.services.loadbalanced"))
 		} else {
 			spec.Add("externalIPs", []string{"192.168.77.77"})
 		}
@@ -239,6 +239,12 @@ func newService(role *model.InstanceGroup, job *model.JobReference, serviceType 
 
 	service := newKubeConfig(settings, "v1", "Service", serviceName)
 	service.Add("spec", spec.Sort())
+
+	if settings.CreateHelmChart && serviceType == newServiceTypePublic {
+		block := `if and .Values.services.loadbalanced .Values.services.ingress`
+		fail := `{{ fail "services.loadbalanced and services.ingress cannot both be set" }}`
+		service.Add("_incompatible", fail, helm.Block(block))
+	}
 
 	return service, nil
 }

--- a/kube/service.go
+++ b/kube/service.go
@@ -213,8 +213,8 @@ func newService(role *model.InstanceGroup, job *model.JobReference, serviceType 
 	}
 	if serviceType == newServiceTypePublic {
 		if settings.CreateHelmChart {
-			spec.Add("externalIPs", "{{ .Values.kube.external_ips | toJson }}", helm.Block("if not .Values.services.loadbalanced"))
-			spec.Add("type", "LoadBalancer", helm.Block("if .Values.services.loadbalanced"))
+			spec.Add("externalIPs", "{{ .Values.kube.external_ips | toJson }}", helm.Block("if or (not .Values.services.loadbalanced) .Values.services.ingress"))
+			spec.Add("type", "LoadBalancer", helm.Block("if and .Values.services.loadbalanced (not .Values.services.ingress)"))
 		} else {
 			spec.Add("externalIPs", []string{"192.168.77.77"})
 		}

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -164,6 +164,43 @@ func TestServiceHelm(t *testing.T) {
 					app.kubernetes.io/component: "myrole"
 		`, actual)
 	})
+
+	t.Run("Ingress", func(t *testing.T) {
+		t.Parallel()
+		config := map[string]interface{}{
+			"Values.services.loadbalanced": "true",
+			"Values.services.ingress":      "nic",
+		}
+		actual, err := RoundtripNode(service, config)
+		require.NoError(t, err)
+		testhelpers.IsYAMLEqualString(assert, `---
+			apiVersion: "v1"
+			kind: "Service"
+			metadata:
+				name: "myrole-tor"
+				labels:
+					app: "myrole-tor"
+					app.kubernetes.io/component: myrole-tor
+					app.kubernetes.io/instance: MyRelease
+					app.kubernetes.io/managed-by: Tiller
+					app.kubernetes.io/name: MyChart
+					app.kubernetes.io/version: 1.22.333.4444
+					helm.sh/chart: MyChart-42.1_foo
+					skiff-role-name: "myrole-tor"
+			spec:
+				ports:
+				-	name: "http"
+					port: 80
+					protocol: "TCP"
+					targetPort: 8080
+				-	name: "https"
+					port: 443
+					protocol: "TCP"
+					targetPort: 443
+				selector:
+					app.kubernetes.io/component: "myrole"
+		`, actual)
+	})
 }
 
 func TestIstioManagedServiceHelm(t *testing.T) {
@@ -231,6 +268,45 @@ func TestIstioManagedServiceHelm(t *testing.T) {
 			"Values.config.use_istio":      true,
 		}
 
+		actual, err := RoundtripNode(service, config)
+		require.NoError(t, err)
+		testhelpers.IsYAMLEqualString(assert, `---
+			apiVersion: "v1"
+			kind: "Service"
+			metadata:
+				name: "myrole-tor"
+				labels:
+					app: myrole-tor
+					app.kubernetes.io/component: myrole-tor
+					app.kubernetes.io/instance: MyRelease
+					app.kubernetes.io/managed-by: Tiller
+					app.kubernetes.io/name: MyChart
+					app.kubernetes.io/version: 1.22.333.4444
+					helm.sh/chart: MyChart-42.1_foo
+					skiff-role-name: "myrole-tor"
+			spec:
+				ports:
+				-	name: "http"
+					port: 80
+					protocol: "TCP"
+					targetPort: 8080
+				-	name: "https"
+					port: 443
+					protocol: "TCP"
+					targetPort: 443
+				selector:
+					app: myrole
+					app.kubernetes.io/component: "myrole"
+		`, actual)
+	})
+
+	t.Run("Ingress", func(t *testing.T) {
+		t.Parallel()
+		config := map[string]interface{}{
+			"Values.services.loadbalanced": "true",
+			"Values.services.ingress":      "nic",
+			"Values.config.use_istio":      true,
+		}
 		actual, err := RoundtripNode(service, config)
 		require.NoError(t, err)
 		testhelpers.IsYAMLEqualString(assert, `---
@@ -395,6 +471,44 @@ func TestHeadlessServiceHelm(t *testing.T) {
 					app.kubernetes.io/component: "myrole"
 		`, actual)
 	})
+
+	t.Run("Ingress", func(t *testing.T) {
+		t.Parallel()
+		config := map[string]interface{}{
+			"Values.services.loadbalanced": "true",
+			"Values.services.ingress":      "nic",
+		}
+		actual, err := RoundtripNode(service, config)
+		require.NoError(t, err)
+		testhelpers.IsYAMLEqualString(assert, `---
+			apiVersion: "v1"
+			kind: "Service"
+			metadata:
+				name: "myservice-set"
+				labels:
+					app: "myservice-set"
+					app.kubernetes.io/component: myservice-set
+					app.kubernetes.io/instance: MyRelease
+					app.kubernetes.io/managed-by: Tiller
+					app.kubernetes.io/name: MyChart
+					app.kubernetes.io/version: 1.22.333.4444
+					helm.sh/chart: MyChart-42.1_foo
+					skiff-role-name: "myservice-set"
+			spec:
+				clusterIP: "None"
+				ports:
+				-	name: "http"
+					port: 80
+					protocol: "TCP"
+					targetPort: 0
+				-	name: "https"
+					port: 443
+					protocol: "TCP"
+					targetPort: 0
+				selector:
+					app.kubernetes.io/component: "myrole"
+		`, actual)
+	})
 }
 
 func TestPublicServiceKube(t *testing.T) {
@@ -515,6 +629,42 @@ func TestPublicServiceHelm(t *testing.T) {
 				selector:
 					app.kubernetes.io/component: "myrole"
 				type:	LoadBalancer
+		`, actual)
+	})
+
+	t.Run("Ingress", func(t *testing.T) {
+		t.Parallel()
+		config := map[string]interface{}{
+			"Values.kube.external_ips":     "[127.0.0.1,127.0.0.2]",
+			"Values.services.loadbalanced": "true",
+			"Values.services.ingress":      "nic",
+		}
+
+		actual, err := RoundtripNode(service, config)
+		require.NoError(t, err)
+		testhelpers.IsYAMLEqualString(assert, `---
+			apiVersion: "v1"
+			kind: "Service"
+			metadata:
+				name: "myrole-tor-public"
+				labels:
+					app: "myrole-tor-public"
+					app.kubernetes.io/component: myrole-tor-public
+					app.kubernetes.io/instance: MyRelease
+					app.kubernetes.io/managed-by: Tiller
+					app.kubernetes.io/name: MyChart
+					app.kubernetes.io/version: 1.22.333.4444
+					helm.sh/chart: MyChart-42.1_foo
+					skiff-role-name: "myrole-tor-public"
+			spec:
+				externalIPs: "[127.0.0.1,127.0.0.2]"
+				ports:
+				-	name: "https"
+					port: 443
+					protocol: "TCP"
+					targetPort: 443
+				selector:
+					app.kubernetes.io/component: "myrole"
 		`, actual)
 	})
 }

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -168,8 +168,7 @@ func TestServiceHelm(t *testing.T) {
 	t.Run("Ingress", func(t *testing.T) {
 		t.Parallel()
 		config := map[string]interface{}{
-			"Values.services.loadbalanced": "true",
-			"Values.services.ingress":      "nic",
+			"Values.services.ingress": "nic",
 		}
 		actual, err := RoundtripNode(service, config)
 		require.NoError(t, err)
@@ -303,9 +302,8 @@ func TestIstioManagedServiceHelm(t *testing.T) {
 	t.Run("Ingress", func(t *testing.T) {
 		t.Parallel()
 		config := map[string]interface{}{
-			"Values.services.loadbalanced": "true",
-			"Values.services.ingress":      "nic",
-			"Values.config.use_istio":      true,
+			"Values.services.ingress": "nic",
+			"Values.config.use_istio": true,
 		}
 		actual, err := RoundtripNode(service, config)
 		require.NoError(t, err)
@@ -475,8 +473,7 @@ func TestHeadlessServiceHelm(t *testing.T) {
 	t.Run("Ingress", func(t *testing.T) {
 		t.Parallel()
 		config := map[string]interface{}{
-			"Values.services.loadbalanced": "true",
-			"Values.services.ingress":      "nic",
+			"Values.services.ingress": "nic",
 		}
 		actual, err := RoundtripNode(service, config)
 		require.NoError(t, err)
@@ -632,12 +629,23 @@ func TestPublicServiceHelm(t *testing.T) {
 		`, actual)
 	})
 
-	t.Run("Ingress", func(t *testing.T) {
+	t.Run("LoadBalancer and Ingress mismatch", func(t *testing.T) {
 		t.Parallel()
 		config := map[string]interface{}{
 			"Values.kube.external_ips":     "[127.0.0.1,127.0.0.2]",
 			"Values.services.loadbalanced": "true",
 			"Values.services.ingress":      "nic",
+		}
+
+		_, err := RoundtripNode(service, config)
+		require.Error(t, err)
+	})
+
+	t.Run("Ingress", func(t *testing.T) {
+		t.Parallel()
+		config := map[string]interface{}{
+			"Values.kube.external_ips": "[127.0.0.1,127.0.0.2]",
+			"Values.services.ingress":  "nic",
 		}
 
 		actual, err := RoundtripNode(service, config)

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -657,7 +657,6 @@ func TestPublicServiceHelm(t *testing.T) {
 					helm.sh/chart: MyChart-42.1_foo
 					skiff-role-name: "myrole-tor-public"
 			spec:
-				externalIPs: "[127.0.0.1,127.0.0.2]"
 				ports:
 				-	name: "https"
 					port: 443

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -129,5 +129,6 @@ func MakeBasicValues() *helm.Mapping {
 		"sizing", helm.NewMapping(),
 		"secrets", helm.NewMapping(),
 		"services", helm.NewMapping(
-			"loadbalanced", false))
+			"loadbalanced", false,
+			"ingress", nil))
 }


### PR DESCRIPTION
 Note that the majority of it is chart-specific (ingress templates, associated cert setup), and outside of the scope for fissile.

Ref: https://trello.com/c/jgev7lC4/892-3-fissile-work-to-use-an-ingress-controller
Ref: https://github.com/cloudfoundry-incubator/fissile/wiki/Managing-Ingress
