### PR TITLE
Rework how we handle PSPs

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -816,7 +816,7 @@ func (f *Fissile) generateAuth(settings kube.ExportSettings) error {
 			accountNames = append(accountNames, fmt.Sprintf("- %s", accountName))
 		}
 		if len(accountNames) < 1 {
-			panic(fmt.Sprintf("Role %s used by no accounts", roleName))
+			panic(fmt.Sprintf("Role \"%s\" used by no accounts", roleName))
 		}
 		if len(accountNames) < 2 {
 			// Ignore roles referenced by a single account. These are not written as their own files,
@@ -829,7 +829,7 @@ func (f *Fissile) generateAuth(settings kube.ExportSettings) error {
 		if err != nil {
 			return err
 		}
-		node.Set(helm.Comment(fmt.Sprintf(`Role %s used by accounts:\n%s`, roleName, strings.Join(accountNames, "\n"))))
+		node.Set(helm.Comment(fmt.Sprintf("Role \"%s\" used by accounts:\n%s", roleName, strings.Join(accountNames, "\n"))))
 		err = f.writeHelmNode(authDir, fmt.Sprintf("auth-role-%s.yaml", roleName), node)
 		if err != nil {
 			return err
@@ -840,10 +840,10 @@ func (f *Fissile) generateAuth(settings kube.ExportSettings) error {
 	for roleName, roleSpec := range settings.RoleManifest.Configuration.Authorization.ClusterRoles {
 		var accountNames []string
 		for accountName := range settings.RoleManifest.Configuration.Authorization.ClusterRoleUsedBy[roleName] {
-			accountNames = append(accountNames, accountName)
+			accountNames = append(accountNames, fmt.Sprintf("- %s", accountName))
 		}
 		if len(accountNames) < 1 {
-			panic(fmt.Sprintf("Cluster role %s used by no accounts", roleName))
+			panic(fmt.Sprintf("Cluster role \"%s\" used by no accounts", roleName))
 		}
 		if len(accountNames) < 2 {
 			// Ignore cluster roles referenced by a single account. These are not written as their own files,
@@ -856,7 +856,7 @@ func (f *Fissile) generateAuth(settings kube.ExportSettings) error {
 		if err != nil {
 			return err
 		}
-		node.Set(helm.Comment(fmt.Sprintf(`Cluster role %s used by accounts %s`, roleName, strings.Join(accountNames, "\n"))))
+		node.Set(helm.Comment(fmt.Sprintf("Cluster role \"%s\" used by accounts:\n%s", roleName, strings.Join(accountNames, "\n"))))
 		err = f.writeHelmNode(authDir, fmt.Sprintf("auth-cluster-role-%s.yaml", roleName), node)
 		if err != nil {
 			return err

--- a/helm/config.go
+++ b/helm/config.go
@@ -146,6 +146,10 @@ type Node interface {
 	// Mapping node methods:
 	Get(...string) Node
 
+	// Match returns true if this Node is a superset of the other Node.
+	// This is meant for use in tests (to locate nodes).
+	Match(Node) bool
+
 	// The write() method implements the part of Encoder.writeNode() that
 	// needs to access the fields specific to each node type. prefix will be
 	// the indented label, either "name:" or "-", depending on whether the
@@ -220,6 +224,15 @@ func (scalar *Scalar) String() string {
 	return scalar.value
 }
 
+// Match returns true if the given node is a scalar with the same value
+func (scalar *Scalar) Match(otherNode Node) bool {
+	other, ok := otherNode.(*Scalar)
+	if !ok {
+		return false
+	}
+	return scalar.value == other.value
+}
+
 func (scalar Scalar) write(enc *Encoder, prefix string) {
 	fmt.Fprintln(enc, prefix+" "+strings.Replace(scalar.value, "\n", "\\n", -1))
 }
@@ -254,6 +267,31 @@ func (list *List) String() string {
 // Values returns a slice of all the elements of the list.
 func (list *List) Values() []Node {
 	return list.nodes
+}
+
+// Match returns true if the given node is a (non-strict) subset of this list
+func (list *List) Match(otherNode Node) bool {
+	other, ok := otherNode.(*List)
+	if !ok {
+		return false
+	}
+	if len(other.nodes) > len(list.nodes) {
+		// The given list has more things, it cannot be a subset
+		return false
+	}
+	listIndex := 0
+	for _, node := range other.nodes {
+		for listIndex < len(list.nodes) {
+			match := node.Match(list.nodes[listIndex])
+			listIndex++
+			if match {
+				// This node matched, continue to the next one
+				break
+			}
+			// Continue matching the next element
+		}
+	}
+	return listIndex < len(list.nodes)
 }
 
 func (list List) write(enc *Encoder, prefix string) {
@@ -344,6 +382,29 @@ func (mapping *Mapping) Names() []string {
 // Merge appends all named nodes from another mapping.
 func (mapping *Mapping) Merge(merge *Mapping) {
 	mapping.nodes = append(mapping.nodes, merge.nodes...)
+}
+
+// Match checks if this mapping is a superset of the given mapping
+func (mapping *Mapping) Match(otherNode Node) bool {
+	other, ok := otherNode.(*Mapping)
+	if !ok {
+		return false
+	}
+targetLoop:
+	for _, targetNamedNode := range other.nodes {
+		for _, namedNode := range mapping.nodes {
+			if targetNamedNode.name == namedNode.name {
+				// Have a match, do a recursive match
+				if !namedNode.node.Match(targetNamedNode.node) {
+					return false
+				}
+				continue targetLoop
+			}
+		}
+		// Getting here means we failed to find the desired name
+		return false
+	}
+	return true
 }
 
 // Sort all nodes of the mapping by name.

--- a/kube/kube_test.go
+++ b/kube/kube_test.go
@@ -13,6 +13,16 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+// fakeAPIVersions exists to hang the `.Capabilities.APIVersions.Has` method off
+// our fake Helm context
+type fakeAPIVersions map[string]interface{}
+
+// Has indicates whether a version ("batch/v1") is enabled on the cluster.
+func (v *fakeAPIVersions) Has(name string) bool {
+	_, ok := (*v)[name]
+	return ok
+}
+
 // RenderNode renders a helm node given the configuration.
 // The configuration may be nil, or map[string]interface{}
 // If it is nil, default values are used.
@@ -32,6 +42,9 @@ func RenderNode(node helm.Node, config interface{}) ([]byte, error) {
 			"KubeVersion": map[string]interface{}{
 				"Major": "1",
 				"Minor": "8",
+			},
+			"APIVersions": &fakeAPIVersions{
+				"rbac.authorization.k8s.io/v1": true,
 			},
 		},
 		"Template": map[string]interface{}{

--- a/kube/kube_test.go
+++ b/kube/kube_test.go
@@ -57,6 +57,9 @@ func RenderNode(node helm.Node, config interface{}) ([]byte, error) {
 
 	var helmConfig, yamlConfig bytes.Buffer
 
+	if node == nil {
+		node = helm.NewNode(nil)
+	}
 	if err := helm.NewEncoder(&helmConfig).Encode(node); err != nil {
 		return nil, err
 	}
@@ -228,4 +231,15 @@ func getBasicConfig() (map[string]interface{}, error) {
 		return nil, err
 	}
 	return converted.(map[string]interface{}), nil
+}
+
+// matchNodeInList iterates through a list of nodes and returns the first one
+// where node.Match(target) succeeds
+func matchNodeInList(list []helm.Node, target helm.Node) helm.Node {
+	for _, node := range list {
+		if node.Match(target) {
+			return node
+		}
+	}
+	return nil
 }

--- a/kube/rbac.go
+++ b/kube/rbac.go
@@ -201,7 +201,10 @@ func NewRBACPSP(name string, psp *model.PodSecurityPolicy, settings ExportSettin
 // authModeRBAC returns a block condition checking for RBAC
 func authModeRBAC(settings ExportSettings) helm.NodeModifier {
 	if settings.CreateHelmChart {
-		return helm.Block(`if eq (printf "%s" .Values.kube.auth) "rbac"`)
+		return helm.Block(fmt.Sprintf(
+			`if and (%s) (%s)`,
+			`eq (printf "%s" .Values.kube.auth) "rbac"`,
+			`.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1"`))
 	}
 	return nil
 }

--- a/kube/rbac.go
+++ b/kube/rbac.go
@@ -7,28 +7,82 @@ import (
 	"code.cloudfoundry.org/fissile/model"
 )
 
+// RBACRoleKind enumerations are for NewRBACRole
+type RBACRoleKind string
+
+const (
+	// RBACRoleKindRole are (namespaced) roles
+	RBACRoleKindRole RBACRoleKind = "Role"
+	// RBACRoleKindClusterRole are cluster roles
+	RBACRoleKindClusterRole RBACRoleKind = "ClusterRole"
+)
+
 // NewRBACAccount creates a new (Kubernetes RBAC) service account and associated
 // bindings.
-func NewRBACAccount(name string, account model.AuthAccount, settings ExportSettings) ([]helm.Node, error) {
+func NewRBACAccount(accountName string, config *model.Configuration, settings ExportSettings) ([]helm.Node, error) {
 	var resources []helm.Node
 	block := authModeRBAC(settings)
 
-	// If we want to modify the default account, there's no need to create it
-	// first -- it already exists
-	if name != "default" {
-		resources = append(resources, newKubeConfig(settings, "v1", "ServiceAccount", name, block))
+	account, ok := config.Authorization.Accounts[accountName]
+	if !ok {
+		return nil, fmt.Errorf("Account %s not found", accountName)
 	}
 
-	for _, role := range account.Roles {
-		binding := newKubeConfig(settings, "rbac.authorization.k8s.io/v1beta1", "RoleBinding", fmt.Sprintf("%s-%s-binding", name, role), block)
+	if len(account.UsedBy) < 1 {
+		// Nothing uses this account
+		// Possibly, we generated a privileged version instead
+		return nil, nil
+	}
+
+	// If we want to modify the default account, there's no need to create it
+	// first -- it already exists
+	if accountName != "default" {
+		description := fmt.Sprintf("Service account %s is used by the following instance groups:", accountName)
+		for instanceGroupName := range account.UsedBy {
+			description += fmt.Sprintf("\n - %s", instanceGroupName)
+		}
+		resources = append(resources, newKubeConfig(settings,
+			"v1",
+			"ServiceAccount",
+			accountName,
+			block,
+			helm.Comment(description)))
+	}
+
+	// For each role, create a role binding
+	for _, roleName := range account.Roles {
+		// Embed the role first, if it's only used by this binding
+		var usedByAccounts []string
+		for accountName := range config.Authorization.RoleUsedBy[roleName] {
+			usedByAccounts = append(usedByAccounts, fmt.Sprintf("- %s", accountName))
+		}
+		if len(usedByAccounts) < 2 {
+			role, err := NewRBACRole(
+				roleName,
+				RBACRoleKindRole,
+				config.Authorization.Roles[roleName],
+				settings)
+			if err != nil {
+				return nil, err
+			}
+			role.Set(helm.Comment(fmt.Sprintf(`Role %s only used by account %s`, roleName, usedByAccounts)))
+			resources = append(resources, role)
+		}
+
+		binding := newKubeConfig(settings,
+			"rbac.authorization.k8s.io/v1",
+			"RoleBinding",
+			fmt.Sprintf("%s-%s-binding", accountName, roleName),
+			block,
+			helm.Comment(fmt.Sprintf("Role binding for service account %s and role %s", accountName, roleName)))
 		subjects := helm.NewList(helm.NewMapping(
 			"kind", "ServiceAccount",
-			"name", name))
+			"name", accountName))
 		binding.Add("subjects", subjects)
 		binding.Add("roleRef", helm.NewMapping(
+			"apiGroup", "rbac.authorization.k8s.io",
 			"kind", "Role",
-			"name", role,
-			"apiGroup", "rbac.authorization.k8s.io"))
+			"name", roleName))
 		resources = append(resources, binding)
 	}
 
@@ -38,25 +92,50 @@ func NewRBACAccount(name string, account model.AuthAccount, settings ExportSetti
 		namespace = "{{ .Release.Namespace }}"
 	}
 
-	binding := newKubeConfig(settings, "rbac.authorization.k8s.io/v1", "ClusterRoleBinding",
-		authCRBindingName(name, settings),
-		authPSPCondition(account.PodSecurityPolicy, settings))
-	subjects := helm.NewList(helm.NewMapping(
-		"kind", "ServiceAccount",
-		"name", name,
-		"namespace", namespace))
-	binding.Add("subjects", subjects)
-	binding.Add("roleRef", helm.NewMapping(
-		"kind", "ClusterRole",
-		"name", authPSPRoleName(account.PodSecurityPolicy, settings),
-		"apiGroup", "rbac.authorization.k8s.io"))
-	resources = append(resources, binding)
+	// For each cluster role, create a cluster role binding
+	// And if the cluster role is only used here, embed that too
+	for _, clusterRoleName := range account.ClusterRoles {
+		// Embed the cluster role first, if it's only used by this binding
+		var accountNames []string
+		for accountName := range config.Authorization.ClusterRoleUsedBy[clusterRoleName] {
+			accountNames = append(accountNames, accountName)
+		}
+		if len(accountNames) < 2 {
+			role, err := NewRBACRole(
+				clusterRoleName,
+				RBACRoleKindClusterRole,
+				config.Authorization.ClusterRoles[clusterRoleName],
+				settings)
+			if err != nil {
+				return nil, err
+			}
+			role.Set(helm.Comment(fmt.Sprintf(`Cluster role %s only used by account %s`, clusterRoleName, accountNames)))
+			resources = append(resources, role)
+		}
+
+		binding := newKubeConfig(settings,
+			"rbac.authorization.k8s.io/v1",
+			"ClusterRoleBinding",
+			authCRBindingName(accountName, clusterRoleName, settings),
+			block,
+			helm.Comment(fmt.Sprintf("Cluster role binding for service account %s and cluster role %s", accountName, clusterRoleName)))
+		subjects := helm.NewList(helm.NewMapping(
+			"kind", "ServiceAccount",
+			"name", accountName,
+			"namespace", namespace))
+		binding.Add("subjects", subjects)
+		binding.Add("roleRef", helm.NewMapping(
+			"kind", "ClusterRole",
+			"name", authCRName(clusterRoleName, settings),
+			"apiGroup", "rbac.authorization.k8s.io"))
+		resources = append(resources, binding)
+	}
 
 	return resources, nil
 }
 
-// NewRBACRole creates a new (Kubernetes RBAC) role
-func NewRBACRole(name string, authRole model.AuthRole, settings ExportSettings) (helm.Node, error) {
+// NewRBACRole creates a new (Kubernetes RBAC) role / cluster role
+func NewRBACRole(name string, kind RBACRoleKind, authRole model.AuthRole, settings ExportSettings) (helm.Node, error) {
 	rules := helm.NewList()
 	for _, ruleSpec := range authRole {
 		rule := helm.NewMapping()
@@ -75,27 +154,54 @@ func NewRBACRole(name string, authRole model.AuthRole, settings ExportSettings) 
 			verbs.Add(verb)
 		}
 		rule.Add("verbs", verbs)
+		if len(ruleSpec.ResourceNames) > 0 {
+			resourceNames := helm.NewList()
+			for _, resourceName := range ruleSpec.ResourceNames {
+				if settings.CreateHelmChart && ruleSpec.IsPodSecurityPolicyRule() {
+					// When creating helm charts for PSPs, let the user override it
+					resourceNames.Add(fmt.Sprintf(
+						`{{ default (printf "%%s-psp-%s" .Release.Namespace) .Values.kube.psp.%s }}`,
+						resourceName,
+						resourceName))
+				} else {
+					resourceNames.Add(resourceName)
+				}
+			}
+			rule.Add("resourceNames", resourceNames)
+		}
 		rules.Add(rule.Sort())
 	}
 
-	role := newKubeConfig(settings, "rbac.authorization.k8s.io/v1beta1", "Role", name, authModeRBAC(settings))
+	if kind == RBACRoleKindClusterRole {
+		name = authCRName(name, settings)
+	}
+	role := newKubeConfig(settings, "rbac.authorization.k8s.io/v1", string(kind), name, authModeRBAC(settings))
 	role.Add("rules", rules)
 
 	return role.Sort(), nil
 }
 
+// NewRBACPSP creates a (Kubernetes RBAC) pod security policy
+func NewRBACPSP(name string, psp *model.PodSecurityPolicy, settings ExportSettings) (helm.Node, error) {
+	var condition helm.NodeModifier
+	if settings.CreateHelmChart {
+		condition = helm.Block(fmt.Sprintf(`if and (%s) (not .Values.kube.psp.%s)`,
+			`eq (printf "%s" .Values.kube.auth) "rbac"`, name))
+		name = fmt.Sprintf(`{{ printf "%%s-psp-%s" .Release.Namespace }}`, name)
+	}
+	node := newKubeConfig(settings,
+		"extensions/v1beta1",
+		"PodSecurityPolicy",
+		name,
+		condition)
+	node.Add("spec", helm.NewNode(psp.Definition))
+	return node, nil
+}
+
+// authModeRBAC returns a block condition checking for RBAC
 func authModeRBAC(settings ExportSettings) helm.NodeModifier {
 	if settings.CreateHelmChart {
 		return helm.Block(`if eq (printf "%s" .Values.kube.auth) "rbac"`)
-	}
-	return nil
-}
-
-// authPSPCondition creates a block condition checking for RBAC and the named PSP
-func authPSPCondition(psp string, settings ExportSettings) helm.NodeModifier {
-	if settings.CreateHelmChart {
-		return helm.Block(fmt.Sprintf(`if and (%s) .Values.kube.psp.%s`,
-			`eq (printf "%s" .Values.kube.auth) "rbac"`, psp))
 	}
 	return nil
 }
@@ -109,33 +215,17 @@ func authPSPRoleName(psp string, settings ExportSettings) string {
 }
 
 // authCRBindingName derives the name of the cluster role for a PSP
-func authCRBindingName(name string, settings ExportSettings) string {
+func authCRBindingName(name, clusterRoleName string, settings ExportSettings) string {
 	if settings.CreateHelmChart {
-		return fmt.Sprintf("{{ .Release.Namespace }}-%s-binding-psp", name)
+		return fmt.Sprintf("{{ .Release.Namespace }}-%s-%s-cluster-binding", name, clusterRoleName)
 	}
-	return fmt.Sprintf("%s-binding-psp", name)
+	return fmt.Sprintf("%s-%s-cluster-binding", name, clusterRoleName)
 }
 
-// NewRBACClusterRolePSP creates a new (Kubernetes RBAC) cluster role
-// referencing a pod security policy (PSP)
-func NewRBACClusterRolePSP(psp string, settings ExportSettings) (helm.Node, error) {
-	name := authPSPRoleName(psp, settings)
-
-	clusterRole := newKubeConfig(settings, "rbac.authorization.k8s.io/v1", "ClusterRole", name, authPSPCondition(psp, settings))
-
+// authCRName derives the cluster role name from the name space
+func authCRName(name string, settings ExportSettings) string {
 	if settings.CreateHelmChart {
-		psp = fmt.Sprintf("{{ .Values.kube.psp.%s | quote }}", psp)
+		return fmt.Sprintf(`{{ .Release.Namespace }}-cluster-role-%s`, name)
 	}
-
-	rules := helm.NewList()
-	rule := helm.NewMapping()
-	rule.Add("apiGroups", helm.NewList("extensions"))
-	rule.Add("resources", helm.NewList("podsecuritypolicies"))
-	rule.Add("verbs", helm.NewList("use"))
-	rule.Add("resourceNames", helm.NewList(psp))
-	rules.Add(rule.Sort())
-
-	clusterRole.Add("rules", rules)
-
-	return clusterRole.Sort(), nil
+	return name
 }

--- a/kube/rbac_test.go
+++ b/kube/rbac_test.go
@@ -3,232 +3,222 @@ package kube
 import (
 	"testing"
 
+	"code.cloudfoundry.org/fissile/helm"
 	"code.cloudfoundry.org/fissile/model"
 	"code.cloudfoundry.org/fissile/testhelpers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewRBACAccountPSPKube(t *testing.T) {
 	t.Parallel()
-	assert := assert.New(t)
 
 	resources, err := NewRBACAccount("the-name",
-		model.AuthAccount{
-			Roles:             []string{"a-role"},
-			PodSecurityPolicy: "privileged",
+		&model.Configuration{
+			Authorization: model.ConfigurationAuthorization{
+				Accounts: map[string]model.AuthAccount{
+					"the-name": {
+						Roles:        []string{"a-role"},
+						ClusterRoles: []string{"privileged-cluster-role"},
+						UsedBy: map[string]struct{}{
+							// This must be used by multiple instance groups to be serialized
+							"foo": struct{}{},
+							"bar": struct{}{},
+						},
+					},
+				},
+			},
 		}, ExportSettings{})
 
-	if !assert.NoError(err) {
-		return
-	}
-	if !assert.Len(resources, 3, "Should have account, role and cluster role bindings") {
-		return
+	require.NoError(t, err)
+
+	account := matchNodeInList(resources, helm.NewMapping("kind", "ServiceAccount"))
+	if assert.NotNil(t, account, "service account not found") {
+		actualAccount, err := RoundtripKube(account)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+			apiVersion: "v1"
+			kind: "ServiceAccount"
+			metadata:
+				name: "the-name"
+				labels:
+					app.kubernetes.io/component: the-name
+		`, actualAccount)
+		}
 	}
 
-	rbacAccount := resources[0]
-	actualAccount, err := RoundtripKube(rbacAccount)
-	if !assert.NoError(err) {
-		return
+	roleBinding := matchNodeInList(resources, helm.NewMapping("kind", "RoleBinding"))
+	if assert.NotNil(t, roleBinding, "role binding not found") {
+		actualRole, err := RoundtripKube(roleBinding)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+				apiVersion: "rbac.authorization.k8s.io/v1"
+				kind: "RoleBinding"
+				metadata:
+					name: "the-name-a-role-binding"
+					labels:
+						app.kubernetes.io/component: the-name-a-role-binding
+				subjects:
+				-	kind: "ServiceAccount"
+					name: "the-name"
+				roleRef:
+					kind: "Role"
+					name: "a-role"
+					apiGroup: "rbac.authorization.k8s.io"
+			`, actualRole)
+		}
 	}
-	testhelpers.IsYAMLEqualString(assert, `---
-		apiVersion: "v1"
-		kind: "ServiceAccount"
-		metadata:
-			name: "the-name"
-			labels:
-				app.kubernetes.io/component: the-name
 
-	`, actualAccount)
-
-	rbacRole := resources[1]
-	actualRole, err := RoundtripKube(rbacRole)
-	if !assert.NoError(err) {
-		return
+	role := matchNodeInList(resources, helm.NewMapping("kind", "Role"))
+	if assert.NotNil(t, role, "role not found") {
+		actualRole, err := RoundtripKube(role)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+				apiVersion: rbac.authorization.k8s.io/v1
+				kind: Role
+				metadata:
+					labels:
+						app.kubernetes.io/component: a-role
+					name: a-role
+				rules: []
+			`, actualRole)
+		}
 	}
-	testhelpers.IsYAMLEqualString(assert, `---
-		apiVersion: "rbac.authorization.k8s.io/v1beta1"
-		kind: "RoleBinding"
-		metadata:
-			name: "the-name-a-role-binding"
-			labels:
-				app.kubernetes.io/component: the-name-a-role-binding
-		subjects:
-		-	kind: "ServiceAccount"
-			name: "the-name"
-		roleRef:
-			kind: "Role"
-			name: "a-role"
-			apiGroup: "rbac.authorization.k8s.io"
-	`, actualRole)
 
-	pspBinding := resources[2]
-	actualBinding, err := RoundtripKube(pspBinding)
-	if !assert.NoError(err) {
-		return
+	clusterRoleBinding := matchNodeInList(resources, helm.NewMapping("kind", "ClusterRoleBinding"))
+	if assert.NotNil(t, clusterRoleBinding, "cluster role binding not found") {
+		actualBinding, err := RoundtripKube(clusterRoleBinding)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+			apiVersion: "rbac.authorization.k8s.io/v1"
+			kind: "ClusterRoleBinding"
+			metadata:
+				name: "the-name-privileged-cluster-role-cluster-binding"
+				labels:
+					app.kubernetes.io/component: the-name-privileged-cluster-role-cluster-binding
+			subjects:
+			-	kind: "ServiceAccount"
+				name: "the-name"
+				namespace: "~"
+			roleRef:
+				kind: "ClusterRole"
+				name: "privileged-cluster-role"
+				apiGroup: "rbac.authorization.k8s.io"
+		`, actualBinding)
+		}
 	}
-	testhelpers.IsYAMLEqualString(assert, `---
-		apiVersion: "rbac.authorization.k8s.io/v1"
-		kind: "ClusterRoleBinding"
-		metadata:
-			name: "the-name-binding-psp"
-			labels:
-				app.kubernetes.io/component: the-name-binding-psp
-		subjects:
-		-	kind: "ServiceAccount"
-			name: "the-name"
-			namespace: "~"
-		roleRef:
-			kind: "ClusterRole"
-			name: "psp-role-privileged"
-			apiGroup: "rbac.authorization.k8s.io"
-	`, actualBinding)
+
+	clusterRole := matchNodeInList(resources, helm.NewMapping("kind", "ClusterRole"))
+	if assert.NotNil(t, clusterRole, "cluster role not found") {
+		actualClusterRole, err := RoundtripKube(clusterRole)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+				apiVersion: rbac.authorization.k8s.io/v1
+				kind: ClusterRole
+				metadata:
+					labels:
+						app.kubernetes.io/component: privileged-cluster-role
+					name: privileged-cluster-role
+				rules: []
+			`, actualClusterRole)
+		}
+	}
+
 }
 
 func TestNewRBACAccountHelm(t *testing.T) {
 	t.Parallel()
-	assert := assert.New(t)
 
 	resources, err := NewRBACAccount("the-name",
-		model.AuthAccount{
-			Roles:             []string{"a-role"},
-			PodSecurityPolicy: "nonprivileged",
+		&model.Configuration{
+			Authorization: model.ConfigurationAuthorization{
+				Accounts: map[string]model.AuthAccount{
+					"the-name": model.AuthAccount{
+						Roles:        []string{"a-role"},
+						ClusterRoles: []string{"nonprivileged"},
+						UsedBy: map[string]struct{}{
+							// This must be used by multiple instance groups to be serialized
+							"foo": struct{}{},
+							"bar": struct{}{},
+						},
+					},
+				},
+				ClusterRoles: map[string]model.AuthRole{
+					"nonprivileged": {
+						{
+							APIGroups:     []string{"policy"},
+							Resources:     []string{"podsecuritypolicies"},
+							ResourceNames: []string{"nonprivileged"},
+							Verbs:         []string{"use"},
+						},
+						{
+							APIGroups:     []string{"imaginary"},
+							Resources:     []string{"other"},
+							ResourceNames: []string{"unchanged"},
+							Verbs:         []string{"yank"},
+						},
+					},
+				},
+			},
 		}, ExportSettings{
 			CreateHelmChart: true,
 		})
 
-	if !assert.NoError(err) {
-		return
-	}
-	if !assert.Len(resources, 3, "Should have account plus role and cluster role bindings") {
-		return
-	}
+	require.NoError(t, err)
+	require.Len(t, resources, 5, "Should have account, role binding, and cluster role binding")
 
-	rbacAccount := resources[0]
-	rbacRole := resources[1]
-	pspBinding := resources[2]
+	account := matchNodeInList(resources, helm.NewMapping("kind", "ServiceAccount"))
+	roleBinding := matchNodeInList(resources, helm.NewMapping("kind", "RoleBinding"))
+	role := matchNodeInList(resources, helm.NewMapping("kind", "Role"))
+	clusterRoleBinding := matchNodeInList(resources, helm.NewMapping("kind", "ClusterRoleBinding"))
+	clusterRole := matchNodeInList(resources, helm.NewMapping("kind", "ClusterRole"))
 
 	t.Run("NoAuth", func(t *testing.T) {
 		t.Parallel()
-		// config: .Values.kube.auth -- helm only ("", "rbac")
-		actualAccount, err := RoundtripNode(rbacAccount, nil)
-		if !assert.NoError(err) {
-			return
-		}
-		testhelpers.IsYAMLEqualString(assert, `---
-		`, actualAccount)
-
-		// config: .Values.kube.auth helm only ("", "rbac")
-		actualRole, err := RoundtripNode(rbacRole, nil)
-		if !assert.NoError(err) {
-			return
-		}
-
-		testhelpers.IsYAMLEqualString(assert, `---
-		`, actualRole)
-	})
-
-	t.Run("HasAuth", func(t *testing.T) {
-		t.Parallel()
 		config := map[string]interface{}{
-			"Values.kube.auth": "rbac",
+			"Values.kube.auth": "",
+		}
+		actualAccount, err := RoundtripNode(account, config)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+			`, actualAccount)
 		}
 
-		actualAccount, err := RoundtripNode(rbacAccount, config)
-		if !assert.NoError(err) {
-			return
+		actualRoleBinding, err := RoundtripNode(roleBinding, config)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+			`, actualRoleBinding)
 		}
 
-		testhelpers.IsYAMLEqualString(assert, `---
-			apiVersion: "v1"
-			kind: "ServiceAccount"
-			metadata:
-				name: "the-name"
-				labels:
-					app.kubernetes.io/component: the-name
-					app.kubernetes.io/instance: MyRelease
-					app.kubernetes.io/managed-by: Tiller
-					app.kubernetes.io/name: MyChart
-					app.kubernetes.io/version: 1.22.333.4444
-					helm.sh/chart: MyChart-42.1_foo
-					skiff-role-name: "the-name"
-		`, actualAccount)
-
-		actualRole, err := RoundtripNode(rbacRole, config)
-		if !assert.NoError(err) {
-			return
+		actualRole, err := RoundtripNode(role, config)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+			`, actualRole)
 		}
 
-		testhelpers.IsYAMLEqualString(assert, `---
-			apiVersion: "rbac.authorization.k8s.io/v1beta1"
-			kind: "RoleBinding"
-			metadata:
-				name: "the-name-a-role-binding"
-				labels:
-					app.kubernetes.io/component: the-name-a-role-binding
-					app.kubernetes.io/instance: MyRelease
-					app.kubernetes.io/managed-by: Tiller
-					app.kubernetes.io/name: MyChart
-					app.kubernetes.io/version: 1.22.333.4444
-					helm.sh/chart: MyChart-42.1_foo
-					skiff-role-name: "the-name-a-role-binding"
-			subjects:
-			-	kind: "ServiceAccount"
-				name: "the-name"
-			roleRef:
-				kind: "Role"
-				name: "a-role"
-				apiGroup: "rbac.authorization.k8s.io"
-		`, actualRole)
+		actualClusterRoleBinding, err := RoundtripNode(clusterRoleBinding, config)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+			`, actualClusterRoleBinding)
+		}
+
+		actualClusterRole, err := RoundtripNode(clusterRole, config)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+			`, actualClusterRole)
+		}
 	})
 
-	t.Run("NoPodSecurityPolicy", func(t *testing.T) {
-		t.Parallel()
-		config := map[string]interface{}{
-			"Values.kube.auth": "rbac",
-		}
-		// config: .Values.kube.psp.nonprivileged: ~
-		actualAccount, err := RoundtripNode(rbacAccount, config)
-		if !assert.NoError(err) {
-			return
-		}
-		testhelpers.IsYAMLEqualString(assert, `---
-			apiVersion: "v1"
-			kind: "ServiceAccount"
-			metadata:
-				name: "the-name"
-				labels:
-					app.kubernetes.io/component: the-name
-					app.kubernetes.io/instance: MyRelease
-					app.kubernetes.io/managed-by: Tiller
-					app.kubernetes.io/name: MyChart
-					app.kubernetes.io/version: 1.22.333.4444
-					helm.sh/chart: MyChart-42.1_foo
-					skiff-role-name: "the-name"
-		`, actualAccount)
-
-		// config: .Values.kube.psp.nonprivileged: ~
-		actualBinding, err := RoundtripNode(pspBinding, config)
-		if !assert.NoError(err) {
-			return
-		}
-
-		testhelpers.IsYAMLEqualString(assert, `---
-		`, actualBinding)
-	})
-
-	t.Run("HasPodSecurityPolicy", func(t *testing.T) {
+	t.Run("DefaultPodSecurityPolicy", func(t *testing.T) {
 		t.Parallel()
 		config := map[string]interface{}{
 			"Values.kube.auth":              "rbac",
-			"Values.kube.psp.nonprivileged": "foo",
-			"Release.Namespace":             "a-namespace",
+			"Values.kube.psp.nonprivileged": nil,
+			"Release.Namespace":             "default-namespace",
 		}
-
-		actualAccount, err := RoundtripNode(rbacAccount, config)
-		if !assert.NoError(err) {
-			return
-		}
-		testhelpers.IsYAMLEqualString(assert, `---
+		actualAccount, err := RoundtripNode(account, config)
+		require.NoError(t, err)
+		testhelpers.IsYAMLEqualString(assert.New(t), `---
 			apiVersion: "v1"
 			kind: "ServiceAccount"
 			metadata:
@@ -243,41 +233,233 @@ func TestNewRBACAccountHelm(t *testing.T) {
 					skiff-role-name: "the-name"
 		`, actualAccount)
 
-		actualBinding, err := RoundtripNode(pspBinding, config)
-		if !assert.NoError(err) {
-			return
+		actualRoleBinding, err := RoundtripNode(roleBinding, config)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+				apiVersion: rbac.authorization.k8s.io/v1
+				kind: RoleBinding
+				metadata:
+					labels:
+						app.kubernetes.io/component: the-name-a-role-binding
+						app.kubernetes.io/instance: MyRelease
+						app.kubernetes.io/managed-by: Tiller
+						app.kubernetes.io/name: MyChart
+						app.kubernetes.io/version: 1.22.333.4444
+						helm.sh/chart: MyChart-42.1_foo
+						skiff-role-name: the-name-a-role-binding
+					name: the-name-a-role-binding
+				roleRef:
+					apiGroup: rbac.authorization.k8s.io
+					kind: Role
+					name: a-role
+				subjects:
+				-	kind: ServiceAccount
+					name: the-name
+			`, actualRoleBinding)
 		}
 
-		testhelpers.IsYAMLEqualString(assert, `---
-			apiVersion: "rbac.authorization.k8s.io/v1"
-			kind: "ClusterRoleBinding"
+		actualRole, err := RoundtripNode(role, config)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+				apiVersion: rbac.authorization.k8s.io/v1
+				kind: Role
+				metadata:
+					labels:
+						app.kubernetes.io/component: a-role
+						app.kubernetes.io/instance: MyRelease
+						app.kubernetes.io/managed-by: Tiller
+						app.kubernetes.io/name: MyChart
+						app.kubernetes.io/version: 1.22.333.4444
+						helm.sh/chart: MyChart-42.1_foo
+						skiff-role-name: a-role
+					name: a-role
+				rules: []
+			`, actualRole)
+		}
+
+		actualClusterRoleBinding, err := RoundtripNode(clusterRoleBinding, config)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+				apiVersion: rbac.authorization.k8s.io/v1
+				kind: ClusterRoleBinding
+				metadata:
+					labels:
+						app.kubernetes.io/component: default-namespace-the-name-nonprivileged-cluster-binding
+						app.kubernetes.io/instance: MyRelease
+						app.kubernetes.io/managed-by: Tiller
+						app.kubernetes.io/name: MyChart
+						app.kubernetes.io/version: 1.22.333.4444
+						helm.sh/chart: MyChart-42.1_foo
+						skiff-role-name: default-namespace-the-name-nonprivileged-cluster-binding
+					name: default-namespace-the-name-nonprivileged-cluster-binding
+				roleRef:
+					apiGroup: rbac.authorization.k8s.io
+					kind: ClusterRole
+					name: default-namespace-cluster-role-nonprivileged
+				subjects:
+				-	kind: ServiceAccount
+					name: the-name
+					namespace: default-namespace
+			`, actualClusterRoleBinding)
+		}
+
+		actualClusterRole, err := RoundtripNode(clusterRole, config)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+				apiVersion: rbac.authorization.k8s.io/v1
+				kind: ClusterRole
+				metadata:
+					labels:
+						app.kubernetes.io/component: default-namespace-cluster-role-nonprivileged
+						app.kubernetes.io/instance: MyRelease
+						app.kubernetes.io/managed-by: Tiller
+						app.kubernetes.io/name: MyChart
+						app.kubernetes.io/version: 1.22.333.4444
+						helm.sh/chart: MyChart-42.1_foo
+						skiff-role-name: default-namespace-cluster-role-nonprivileged
+					name: default-namespace-cluster-role-nonprivileged
+				rules:
+				-	apiGroups: [policy]
+					resources: [podsecuritypolicies]
+					verbs: [use]
+					resourceNames: [default-namespace-psp-nonprivileged]
+				-	apiGroups:     [imaginary]
+					resourceNames: [unchanged]
+					resources:     [other]
+					verbs:         [yank]
+			`, actualClusterRole)
+		}
+	})
+
+	t.Run("OverridePodSecurityPolicy", func(t *testing.T) {
+		t.Parallel()
+		config := map[string]interface{}{
+			"Values.kube.auth":              "rbac",
+			"Values.kube.psp.nonprivileged": "psp-name",
+			"Release.Namespace":             "a-namespace",
+		}
+
+		actualAccount, err := RoundtripNode(account, config)
+		require.NoError(t, err)
+		testhelpers.IsYAMLEqualString(assert.New(t), `---
+			apiVersion: "v1"
+			kind: "ServiceAccount"
 			metadata:
-				name: "a-namespace-the-name-binding-psp"
+				name: "the-name"
 				labels:
-					app.kubernetes.io/component: a-namespace-the-name-binding-psp
+					app.kubernetes.io/component: the-name
 					app.kubernetes.io/instance: MyRelease
 					app.kubernetes.io/managed-by: Tiller
 					app.kubernetes.io/name: MyChart
 					app.kubernetes.io/version: 1.22.333.4444
 					helm.sh/chart: MyChart-42.1_foo
-					skiff-role-name: "a-namespace-the-name-binding-psp"
-			subjects:
-			-	kind: "ServiceAccount"
-				name: "the-name"
-				namespace: "a-namespace"
-			roleRef:
-				kind: "ClusterRole"
-				name: "a-namespace-psp-role-nonprivileged"
-				apiGroup: "rbac.authorization.k8s.io"
-		`, actualBinding)
+					skiff-role-name: "the-name"
+		`, actualAccount)
+
+		actualRoleBinding, err := RoundtripNode(roleBinding, config)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+				apiVersion: rbac.authorization.k8s.io/v1
+				kind: RoleBinding
+				metadata:
+					labels:
+						app.kubernetes.io/component: the-name-a-role-binding
+						app.kubernetes.io/instance: MyRelease
+						app.kubernetes.io/managed-by: Tiller
+						app.kubernetes.io/name: MyChart
+						app.kubernetes.io/version: 1.22.333.4444
+						helm.sh/chart: MyChart-42.1_foo
+						skiff-role-name: the-name-a-role-binding
+					name: the-name-a-role-binding
+				roleRef:
+					apiGroup: rbac.authorization.k8s.io
+					kind: Role
+					name: a-role
+				subjects:
+				-	kind: ServiceAccount
+					name: the-name
+			`, actualRoleBinding)
+		}
+
+		actualRole, err := RoundtripNode(role, config)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+				apiVersion: rbac.authorization.k8s.io/v1
+				kind: Role
+				metadata:
+					labels:
+						app.kubernetes.io/component: a-role
+						app.kubernetes.io/instance: MyRelease
+						app.kubernetes.io/managed-by: Tiller
+						app.kubernetes.io/name: MyChart
+						app.kubernetes.io/version: 1.22.333.4444
+						helm.sh/chart: MyChart-42.1_foo
+						skiff-role-name: a-role
+					name: a-role
+				rules: []
+			`, actualRole)
+		}
+
+		actualClusterRoleBinding, err := RoundtripNode(clusterRoleBinding, config)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+				apiVersion: "rbac.authorization.k8s.io/v1"
+				kind: "ClusterRoleBinding"
+				metadata:
+					name: "a-namespace-the-name-nonprivileged-cluster-binding"
+					labels:
+						app.kubernetes.io/component: a-namespace-the-name-nonprivileged-cluster-binding
+						app.kubernetes.io/instance: MyRelease
+						app.kubernetes.io/managed-by: Tiller
+						app.kubernetes.io/name: MyChart
+						app.kubernetes.io/version: 1.22.333.4444
+						helm.sh/chart: MyChart-42.1_foo
+						skiff-role-name: "a-namespace-the-name-nonprivileged-cluster-binding"
+				subjects:
+				-	kind: "ServiceAccount"
+					name: "the-name"
+					namespace: "a-namespace"
+				roleRef:
+					kind: "ClusterRole"
+					name: "a-namespace-cluster-role-nonprivileged"
+					apiGroup: "rbac.authorization.k8s.io"
+			`, actualClusterRoleBinding)
+		}
+
+		actualClusterRole, err := RoundtripNode(clusterRole, config)
+		if assert.NoError(t, err) {
+			testhelpers.IsYAMLEqualString(assert.New(t), `---
+				apiVersion: rbac.authorization.k8s.io/v1
+				kind: ClusterRole
+				metadata:
+					labels:
+						app.kubernetes.io/component: a-namespace-cluster-role-nonprivileged
+						app.kubernetes.io/instance: MyRelease
+						app.kubernetes.io/managed-by: Tiller
+						app.kubernetes.io/name: MyChart
+						app.kubernetes.io/version: 1.22.333.4444
+						helm.sh/chart: MyChart-42.1_foo
+						skiff-role-name: a-namespace-cluster-role-nonprivileged
+					name: a-namespace-cluster-role-nonprivileged
+				rules:
+				-	apiGroups:     [policy]
+					resourceNames: [psp-name]
+					resources:     [podsecuritypolicies]
+					verbs:         [use]
+				-	apiGroups:     [imaginary]
+					resourceNames: [unchanged]
+					resources:     [other]
+					verbs:         [yank]
+			`, actualClusterRole)
+		}
 	})
 }
 
 func TestNewRBACRoleKube(t *testing.T) {
 	t.Parallel()
-	assert := assert.New(t)
 
 	rbacRole, err := NewRBACRole("the-name",
+		RBACRoleKindRole,
 		[]model.AuthRule{
 			{
 				APIGroups: []string{"api-group-1"},
@@ -287,16 +469,12 @@ func TestNewRBACRoleKube(t *testing.T) {
 		},
 		ExportSettings{})
 
-	if !assert.NoError(err) {
-		return
-	}
+	require.NoError(t, err)
 
 	actual, err := RoundtripKube(rbacRole)
-	if !assert.NoError(err) {
-		return
-	}
-	testhelpers.IsYAMLEqualString(assert, `---
-		apiVersion: "rbac.authorization.k8s.io/v1beta1"
+	require.NoError(t, err)
+	testhelpers.IsYAMLEqualString(assert.New(t), `---
+		apiVersion: "rbac.authorization.k8s.io/v1"
 		kind: "Role"
 		metadata:
 			name: "the-name"
@@ -314,9 +492,9 @@ func TestNewRBACRoleKube(t *testing.T) {
 
 func TestNewRBACRoleHelm(t *testing.T) {
 	t.Parallel()
-	assert := assert.New(t)
 
 	rbacRole, err := NewRBACRole("the-name",
+		RBACRoleKindRole,
 		[]model.AuthRule{
 			{
 				APIGroups: []string{"api-group-1"},
@@ -328,9 +506,7 @@ func TestNewRBACRoleHelm(t *testing.T) {
 			CreateHelmChart: true,
 		})
 
-	if !assert.NoError(err) {
-		return
-	}
+	require.NoError(t, err)
 
 	t.Run("NoAuth", func(t *testing.T) {
 		t.Parallel()
@@ -339,11 +515,9 @@ func TestNewRBACRoleHelm(t *testing.T) {
 		}
 
 		actual, err := RoundtripNode(rbacRole, config)
-		if !assert.NoError(err) {
-			return
-		}
+		require.NoError(t, err)
 
-		testhelpers.IsYAMLEqualString(assert, `---
+		testhelpers.IsYAMLEqualString(assert.New(t), `---
 		`, actual)
 	})
 
@@ -354,12 +528,10 @@ func TestNewRBACRoleHelm(t *testing.T) {
 		}
 
 		actual, err := RoundtripNode(rbacRole, config)
-		if !assert.NoError(err) {
-			return
-		}
+		require.NoError(t, err)
 
-		testhelpers.IsYAMLEqualString(assert, `---
-			apiVersion: "rbac.authorization.k8s.io/v1beta1"
+		testhelpers.IsYAMLEqualString(assert.New(t), `---
+			apiVersion: "rbac.authorization.k8s.io/v1"
 			kind: "Role"
 			metadata:
 				name: "the-name"
@@ -382,6 +554,7 @@ func TestNewRBACRoleHelm(t *testing.T) {
 	})
 }
 
+/*
 func TestNewRBACClusterRolePSPKube(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
@@ -461,3 +634,4 @@ func TestNewRBACClusterRolePSPHelm(t *testing.T) {
 			-	"use"
 	`, actualCR)
 }
+*/

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -95,17 +95,12 @@ func minKubeVersion(major, minor int) string {
 // access them.
 func MakeBasicValues() *helm.Mapping {
 
-	psp := helm.NewMapping()
-	for _, pspName := range model.PodSecurityPolicies() {
-		psp.Add(pspName, nil)
-	}
-
 	return helm.NewMapping(
 		"kube", helm.NewMapping(
 			"external_ips", helm.NewList(),
 			"secrets_generation_counter", helm.NewNode(1, helm.Comment("Increment this counter to rotate all generated secrets")),
 			"storage_class", helm.NewMapping("persistent", "persistent", "shared", "shared"),
-			"psp", psp,
+			"psp", helm.NewMapping(),
 			"hostpath_available", helm.NewNode(false, helm.Comment("Whether HostPath volume mounts are available")),
 			"registry", helm.NewMapping(
 				"hostname", "docker.io",

--- a/kube/values.go
+++ b/kube/values.go
@@ -196,6 +196,12 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 	if settings.AuthType != "" {
 		kube.Add("auth", settings.AuthType)
 	}
+	psps := helm.NewMapping()
+	for pspName := range settings.RoleManifest.Configuration.Authorization.PodSecurityPolicies {
+		psps.Add(pspName, nil)
+	}
+	kube.Add("psp", psps.Sort())
+	kube.Sort()
 
 	return values, nil
 }

--- a/model/resolver/resolver.go
+++ b/model/resolver/resolver.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"fmt"
+	"sort"
 
 	"code.cloudfoundry.org/fissile/model"
 	"code.cloudfoundry.org/fissile/util"
@@ -473,6 +474,7 @@ func resolvePodSecurityPolicies(m *model.RoleManifest) validation.ErrorList {
 	for i := range instanceGroupsNeedingEscalation {
 		instanceGroupNames = append(instanceGroupNames, m.InstanceGroups[i].Name)
 	}
+	sort.Strings(instanceGroupNames)
 	fmt.Printf("Found %d instance groups requiring escalation: %s\n", len(instanceGroupsNeedingEscalation), instanceGroupNames)
 
 	// Find a PSP to use as the privileged PSP

--- a/model/resolver/resolver.go
+++ b/model/resolver/resolver.go
@@ -112,8 +112,12 @@ func (r *Resolver) ResolveRoleManifest() error {
 		m.Configuration.Authorization.Accounts = make(map[string]model.AuthAccount)
 	}
 
-	if m.Configuration.Authorization.RoleUse == nil {
-		m.Configuration.Authorization.RoleUse = make(map[string]int)
+	if m.Configuration.Authorization.RoleUsedBy == nil {
+		m.Configuration.Authorization.RoleUsedBy = make(map[string]map[string]struct{})
+	}
+
+	if m.Configuration.Authorization.ClusterRoleUsedBy == nil {
+		m.Configuration.Authorization.ClusterRoleUsedBy = make(map[string]map[string]struct{})
 	}
 
 	for _, instanceGroup := range m.InstanceGroups {
@@ -139,16 +143,23 @@ func (r *Resolver) ResolveRoleManifest() error {
 		// Count how many instance groups use a particular
 		// service account. And its roles.
 
+		accountName := "default"
 		if instanceGroup.Run != nil {
-			account := m.Configuration.Authorization.Accounts[instanceGroup.Run.ServiceAccount]
-			account.NumGroups++
-			m.Configuration.Authorization.Accounts[instanceGroup.Run.ServiceAccount] = account
+			accountName = instanceGroup.Run.ServiceAccount
+		}
+		account := m.Configuration.Authorization.Accounts[accountName]
 
-			for _, roleName := range account.Roles {
-				role := m.Configuration.Authorization.RoleUse[roleName]
-				role++
-				m.Configuration.Authorization.RoleUse[roleName] = role
+		for _, roleName := range account.Roles {
+			if m.Configuration.Authorization.RoleUsedBy[roleName] == nil {
+				m.Configuration.Authorization.RoleUsedBy[roleName] = make(map[string]struct{})
 			}
+			m.Configuration.Authorization.RoleUsedBy[roleName][accountName] = struct{}{}
+		}
+		for _, clusterRoleName := range account.ClusterRoles {
+			if m.Configuration.Authorization.ClusterRoleUsedBy[clusterRoleName] == nil {
+				m.Configuration.Authorization.ClusterRoleUsedBy[clusterRoleName] = make(map[string]struct{})
+			}
+			m.Configuration.Authorization.ClusterRoleUsedBy[clusterRoleName][accountName] = struct{}{}
 		}
 	}
 
@@ -194,13 +205,14 @@ func (r *Resolver) ResolveRoleManifest() error {
 		if !r.releaseResolver.CanValidate() {
 			allErrs = append(allErrs, validateScripts(m, r.options.ValidationOptions)...)
 		}
+		allErrs = append(allErrs, resolvePodSecurityPolicies(m)...)
 	}
 
 	if len(allErrs) != 0 {
 		return fmt.Errorf(allErrs.Errors())
 	}
 
-	return resolvePodSecurityPolicies(m)
+	return nil
 }
 
 // ResolveLinks examines the BOSH links specified in the job specs and maps
@@ -336,59 +348,212 @@ func (r *Resolver) ResolveLinks() validation.ErrorList {
 	return errors
 }
 
-// resolvePodSecurityPolicies moves the PSP information found in
-// RoleManifest.InstanceGroup.JobReferences[].ContainerProperties.BoshContainerization.PodSecurityPolicy to
-// RoleManifest.Configuration.Authorization.Accounts[].PodSecurityPolicy
-// As service accounts can reference only one PSP the operation makes
-// clones of the base SA as needed. Note that the clones reference the same
-// roles as the base, and that the roles are not cloned.
-func resolvePodSecurityPolicies(m *model.RoleManifest) error {
-	for _, instanceGroup := range m.InstanceGroups {
-		// Note: validateRoleRun ensured non-nil of instanceGroup.Run
+// resolvePodSecurityPolicies ensures that the pod security policies (PSPs) are
+// in a sane state:
+// - RoleManifest.Configuration.Authorization.Accounts can reference multiple cluster-roles
+// - The cluster roles are specified in
+//   RoleManifest.Configuration.Authorization.ClusterRoles
+// - The cluster role may be able to use PSPs
+// - If no PSPs are specified for an account, then the instance group may specify if it needs to be privileged via
+//   RoleManifest.InstanceGroup.JobReferences[].ContainerProperties.BoshContainerization.PodSecurityPolicy
+// - If using the backwards compatibility key, then if a privileged PSP is requested but the service account is not
+//   normally bound to a privileged PSP, a duplicate of the service account is created with a binding to the PSP (where
+//   the name of the new service account is the old names with a "-privileged" suffix).
+func resolvePodSecurityPolicies(m *model.RoleManifest) validation.ErrorList {
+	errors := make(validation.ErrorList, 0)
 
-		pspName := instanceGroup.PodSecurityPolicy()
-		accountName := instanceGroup.Run.ServiceAccount
-		account, ok := m.Configuration.Authorization.Accounts[accountName]
+	// Calculate what PSPs are attached to each cluster role
+	// Calculate whether each service account has a privileged PSP attached
+	// Find instance groups with insufficient privileges (and their service accounts)
+	// If no instance groups require more privileges, stop.
+	// Find a PSP to use as the privileged PSP
+	// Create a cluster role to use that PSP (if necessary)
+	// For each inadequate account, create a clone
+	// Fix up instance groups to use the cloned accounts
 
-		if account.PodSecurityPolicy == "" {
-			// The account has no PSP information at all.
-			// Have it use the PSP of this group
-			if !ok {
-				m.Configuration.Authorization.Accounts = make(map[string]model.AuthAccount)
+	// Calculate what PSPs are attached to each cluster role
+	clusterRolePSPNames := make(map[string][]string)
+	for clusterRoleName, clusterRole := range m.Configuration.Authorization.ClusterRoles {
+		for _, rule := range clusterRole {
+			if !rule.IsPodSecurityPolicyRule() {
+				continue
 			}
-			account.PodSecurityPolicy = pspName
-			m.Configuration.Authorization.Accounts[accountName] = account
-			continue
+			for _, resourceName := range rule.ResourceNames {
+				if _, ok := m.Configuration.Authorization.PodSecurityPolicies[resourceName]; ok {
+					clusterRolePSPNames[clusterRoleName] = append(clusterRolePSPNames[clusterRoleName], resourceName)
+				} else {
+					errors = append(errors, validation.NotFound(
+						fmt.Sprintf(`configuration.auth.cluster-roles[%s]`, clusterRoleName),
+						fmt.Sprintf(`pod security policy %s`, resourceName)))
+				}
+			}
 		}
-
-		if account.PodSecurityPolicy == pspName {
-			// The account's PSP matches the group-requested PSP.
-			// There is nothing to do.
-			continue
-		}
-
-		// The group references a service account which
-		// references a different PSP than the group
-		// expects. To fix this we:
-		// 1. Clone the account
-		// 2. Set the clone's PSP to the group's PSP
-		// 3. Add the clone to the map, under a new name.
-		// 4. Change the group to reference the clone
-		//
-		// However: The clone may already exist. In that case
-		// only step 4 is needed.
-
-		newAccountName := fmt.Sprintf("%s-%s", accountName, pspName)
-
-		if _, ok := m.Configuration.Authorization.Accounts[newAccountName]; !ok {
-			newAccount := account
-			newAccount.PodSecurityPolicy = pspName
-
-			m.Configuration.Authorization.Accounts[newAccountName] = newAccount
-		}
-
-		instanceGroup.Run.ServiceAccount = newAccountName
 	}
 
-	return nil
+	// Calculate whether each service account has a privileged PSP attached
+	serviceAccountHasPrivilegedPSP := make(map[string]bool)
+	for accountName, account := range m.Configuration.Authorization.Accounts {
+		serviceAccountHasPrivilegedPSP[accountName] = false
+		for clusterRoleIndex, clusterRoleName := range account.ClusterRoles {
+			_, ok := m.Configuration.Authorization.ClusterRoles[clusterRoleName]
+			if !ok {
+				// cluster role is missing
+				errors = append(errors, validation.NotFound(
+					fmt.Sprintf(`configuration.auth.accounts[%s].cluster-roles[%d]`, accountName, clusterRoleIndex),
+					fmt.Sprintf(`cluster role name %s`, clusterRoleName)))
+				continue
+			}
+			for _, clusterRolePSPName := range clusterRolePSPNames[clusterRoleName] {
+				psp := m.Configuration.Authorization.PodSecurityPolicies[clusterRolePSPName]
+				if psp.PrivilegeEscalationAllowed() {
+					serviceAccountHasPrivilegedPSP[accountName] = true
+				}
+				break
+			}
+		}
+	}
+
+	// Find instance groups with insufficient privileges (and their service accounts)
+	accountsNeedingEscalation := make(map[string][]int)
+	instanceGroupsNeedingEscalation := make(map[int]struct{})
+	for instanceGroupIndex, instanceGroup := range m.InstanceGroups {
+		serviceAccountName := instanceGroup.Run.ServiceAccount
+		serviceAccount := m.Configuration.Authorization.Accounts[serviceAccountName]
+
+		if serviceAccount.UsedBy == nil {
+			serviceAccount.UsedBy = make(map[string]struct{})
+		}
+		serviceAccount.UsedBy[instanceGroup.Name] = struct{}{}
+		m.Configuration.Authorization.Accounts[serviceAccountName] = serviceAccount
+
+		if e := instanceGroup.EnsureValidPodSecurityPolicyPrivilege(); e != nil {
+			// Instance group has invalid values
+			details := e.(*model.InvalidPodSecurityPolicyPrivilegeError)
+			errors = append(errors, validation.Invalid(
+				fmt.Sprintf(`instance_groups[%s].jobs[%s].properties.bosh_containerization.pod-security-policy`,
+					instanceGroup.Name,
+					details.JobName),
+				details.Value,
+				fmt.Sprintf("Expected one of: %s, %s",
+					model.PodSecurityPolicyNonPrivileged,
+					model.PodSecurityPolicyPrivileged)))
+			continue
+		}
+
+		if !instanceGroup.IsPrivilegedPodSecurityPolicy() {
+			// Ignore any instance groups that don't request extra privileges
+			continue
+		}
+		privilegedAccount, ok := serviceAccountHasPrivilegedPSP[serviceAccountName]
+		if !ok {
+			if serviceAccountName == "default" {
+				// Create a dummy one instead
+				privilegedAccount = false
+			} else {
+				errors = append(errors, validation.NotFound(
+					fmt.Sprintf(`instance_groups[%s].run.service-account`, instanceGroup.Name),
+					fmt.Sprintf(`service account %s`, serviceAccountName)))
+				continue
+			}
+		}
+
+		if privilegedAccount {
+			// service account is already privileged, no need to escalate
+			continue
+		}
+		accountsNeedingEscalation[serviceAccountName] = append(accountsNeedingEscalation[serviceAccountName], instanceGroupIndex)
+		instanceGroupsNeedingEscalation[instanceGroupIndex] = struct{}{}
+	}
+
+	// If no instance groups require more privileges, stop.
+	if len(instanceGroupsNeedingEscalation) < 1 {
+		return errors
+	}
+	instanceGroupNames := make([]string, 0, len(instanceGroupsNeedingEscalation))
+	for i := range instanceGroupsNeedingEscalation {
+		instanceGroupNames = append(instanceGroupNames, m.InstanceGroups[i].Name)
+	}
+	fmt.Printf("Found %d instance groups requiring escalation: %s\n", len(instanceGroupsNeedingEscalation), instanceGroupNames)
+
+	// Find a PSP to use as the privileged PSP
+	defaultPrivilegedPSPName := "privileged"
+	for pspName, psp := range m.Configuration.Authorization.PodSecurityPolicies {
+		if util.StringInSlice(pspName, []string{"privileged", "default"}) {
+			if psp.PrivilegeEscalationAllowed() {
+				defaultPrivilegedPSPName = pspName
+				break
+			}
+		}
+	}
+
+	// Create a cluster role to use that PSP (if necessary)
+	var defaultPrivilegedClusterRoleName string
+	if m.Configuration.Authorization.ClusterRoles == nil {
+		m.Configuration.Authorization.ClusterRoles = make(map[string]model.AuthRole)
+	}
+clusterRoleLoop:
+	for clusterRoleName, clusterRole := range m.Configuration.Authorization.ClusterRoles {
+		for _, rule := range clusterRole {
+			if !rule.IsPodSecurityPolicyRule() {
+				continue
+			}
+			if util.StringInSlice(defaultPrivilegedPSPName, rule.ResourceNames) {
+				defaultPrivilegedClusterRoleName = clusterRoleName
+				break clusterRoleLoop
+			}
+		}
+	}
+	if defaultPrivilegedClusterRoleName == "" {
+		newClusterRole := model.AuthRole{model.AuthRule{
+			APIGroups:     []string{"extensions"},
+			Verbs:         []string{"use"},
+			Resources:     []string{"podsecuritypolicies"},
+			ResourceNames: []string{defaultPrivilegedPSPName},
+		}}
+		defaultPrivilegedClusterRoleName = "default-privileged"
+		m.Configuration.Authorization.ClusterRoles[defaultPrivilegedClusterRoleName] = newClusterRole
+	}
+
+	// For each inadequate account, create a clone (with corresponding cluster role)
+	for oldAccountName, affectedInstanceGroups := range accountsNeedingEscalation {
+		newAccountName := fmt.Sprintf("%s-privileged", oldAccountName)
+		oldAccount := m.Configuration.Authorization.Accounts[oldAccountName]
+		newAccount, ok := m.Configuration.Authorization.Accounts[newAccountName]
+		if !ok {
+			// The account didn't previously exist; create it by copying the old one
+			newAccount = model.AuthAccount{
+				Roles:        append(oldAccount.Roles),
+				ClusterRoles: append(oldAccount.ClusterRoles, defaultPrivilegedClusterRoleName),
+				UsedBy:       make(map[string]struct{}),
+			}
+			// Mark the roles as being used by the new account
+			for _, roleName := range newAccount.Roles {
+				m.Configuration.Authorization.RoleUsedBy[roleName][newAccountName] = struct{}{}
+			}
+			for _, clusterRoleName := range newAccount.ClusterRoles {
+				if m.Configuration.Authorization.ClusterRoleUsedBy[clusterRoleName] == nil {
+					// If we just created the default privileged cluster role, it has no counter yet
+					m.Configuration.Authorization.ClusterRoleUsedBy[clusterRoleName] = make(map[string]struct{})
+				}
+				m.Configuration.Authorization.ClusterRoleUsedBy[clusterRoleName][newAccountName] = struct{}{}
+			}
+		}
+		// Transfer the usage from the old account to the new account
+		for _, instanceGroupIndex := range affectedInstanceGroups {
+			instanceGroupName := m.InstanceGroups[instanceGroupIndex].Name
+			delete(oldAccount.UsedBy, instanceGroupName)
+			newAccount.UsedBy[instanceGroupName] = struct{}{}
+		}
+		m.Configuration.Authorization.Accounts[oldAccountName] = oldAccount
+		m.Configuration.Authorization.Accounts[newAccountName] = newAccount
+	}
+
+	// Fix up instance groups to use the cloned accounts
+	for instanceGroupIndex := range instanceGroupsNeedingEscalation {
+		instanceGroup := m.InstanceGroups[instanceGroupIndex]
+		oldAccountName := instanceGroup.Run.ServiceAccount
+		newAccountName := fmt.Sprintf("%s-privileged", oldAccountName)
+		instanceGroup.Run.ServiceAccount = newAccountName
+	}
+	return errors
 }

--- a/model/resolver/validation_role_run.go
+++ b/model/resolver/validation_role_run.go
@@ -3,7 +3,6 @@ package resolver
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
 	"code.cloudfoundry.org/fissile/model"
 	"code.cloudfoundry.org/fissile/validation"
@@ -55,19 +54,6 @@ func validateJobReferences(instanceGroup *model.InstanceGroup) validation.ErrorL
 	for _, job := range instanceGroup.JobReferences {
 		for idx := range job.ContainerProperties.BoshContainerization.Ports {
 			allErrs = append(allErrs, validateExposedPorts(instanceGroup.Name, job.Name, &job.ContainerProperties.BoshContainerization.Ports[idx])...)
-		}
-
-		// Validate pod security policy, or default to least
-		if job.ContainerProperties.BoshContainerization.PodSecurityPolicy == "" {
-			job.ContainerProperties.BoshContainerization.PodSecurityPolicy = model.LeastPodSecurityPolicy()
-		} else {
-			if !model.ValidPodSecurityPolicy(job.ContainerProperties.BoshContainerization.PodSecurityPolicy) {
-				msg := fmt.Sprintf("Expected one of: %s", strings.Join(model.PodSecurityPolicies(), ", "))
-				ref := fmt.Sprintf("instance_groups[%s].jobs[%s].properties.bosh_containerization.pod-security-policy",
-					instanceGroup.Name, job.Name)
-				allErrs = append(allErrs, validation.Invalid(
-					ref, job.ContainerProperties.BoshContainerization.PodSecurityPolicy, msg))
-			}
 		}
 	}
 

--- a/test-assets/role-manifests/app/generate-auth.yml
+++ b/test-assets/role-manifests/app/generate-auth.yml
@@ -24,9 +24,19 @@ configuration:
       non-default:
         roles:
         - extra-permissions
+        cluster-roles:
+        - nonprivileged
       default:
         roles:
         - pointless
+    cluster-roles:
+      nonprivileged:
+      - apiGroups: [extensions]
+        resourceNames: [nonprivileged]
+        resources: [podsecuritypolicies]
+        verbs: [use]
+    pod-security-policies:
+      nonprivileged: {}
     roles:
       extra-permissions:
       - apiGroups: ['']

--- a/util/string_utils.go
+++ b/util/string_utils.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"strings"
+)
+
+// StringInSlice checks if the given string is in the given string slice, ignoring case differences
+func StringInSlice(needle string, haystack []string) bool {
+	for _, element := range haystack {
+		if strings.EqualFold(needle, element) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
We now allow the role manifest to list the PSPs / roles / cluster roles explicitly.  This way the deployment can customize what sort of (cluster) roles it wants (e.g. perhaps only one role needs to read node labels).

This should be backwards compatible: this should work with an unmodified SCF deployment.