### PR TITLE
Set config.use_istio to false by default in values.yaml

### DIFF
--- a/kube/job_test.go
+++ b/kube/job_test.go
@@ -176,7 +176,6 @@ func TestJobHelm(t *testing.T) {
 				metadata:
 					name: "pre-role"
 					labels:
-						app: "pre-role"
 						app.kubernetes.io/component: pre-role
 						app.kubernetes.io/instance: MyRelease
 						app.kubernetes.io/managed-by: Tiller
@@ -184,7 +183,6 @@ func TestJobHelm(t *testing.T) {
 						app.kubernetes.io/version: 1.22.333.4444
 						helm.sh/chart: MyChart-42.1_foo
 						skiff-role-name: "pre-role"
-						version: 1.22.333.4444
 					annotations:
 						checksum/config: 08c80ed11902eefef09739d41c91408238bb8b5e7be7cc1e5db933b7c8de65c3
 				spec:

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -1726,7 +1726,6 @@ func TestPodPreFlightHelm(t *testing.T) {
 		metadata:
 			name: "pre-role"
 			labels:
-				app: "pre-role"
 				app.kubernetes.io/component: pre-role
 				app.kubernetes.io/instance: MyRelease
 				app.kubernetes.io/managed-by: Tiller
@@ -1734,7 +1733,6 @@ func TestPodPreFlightHelm(t *testing.T) {
 				app.kubernetes.io/version: 1.22.333.4444
 				helm.sh/chart: MyChart-42.1_foo
 				skiff-role-name: "pre-role"
-				version: 1.22.333.4444
 		spec:
 			containers:
 			-	env:
@@ -1846,7 +1844,6 @@ func TestPodPostFlightHelm(t *testing.T) {
 		metadata:
 			name: "post-role"
 			labels:
-				app: "post-role"
 				app.kubernetes.io/component: post-role
 				app.kubernetes.io/instance: MyRelease
 				app.kubernetes.io/managed-by: Tiller
@@ -1854,7 +1851,6 @@ func TestPodPostFlightHelm(t *testing.T) {
 				app.kubernetes.io/version: 1.22.333.4444
 				helm.sh/chart: MyChart-42.1_foo
 				skiff-role-name: "post-role"
-				version: 1.22.333.4444
 		spec:
 			containers:
 			-	env:
@@ -1976,7 +1972,6 @@ func TestPodMemoryHelmDisabled(t *testing.T) {
 		metadata:
 			name: "pre-role"
 			labels:
-				app: "pre-role"
 				app.kubernetes.io/component: pre-role
 				app.kubernetes.io/instance: MyRelease
 				app.kubernetes.io/managed-by: Tiller
@@ -1984,7 +1979,6 @@ func TestPodMemoryHelmDisabled(t *testing.T) {
 				app.kubernetes.io/version: 1.22.333.4444
 				helm.sh/chart: MyChart-42.1_foo
 				skiff-role-name: "pre-role"
-				version: 1.22.333.4444
 		spec:
 			containers:
 			-	env:
@@ -2069,7 +2063,6 @@ func TestPodMemoryHelmActive(t *testing.T) {
 		metadata:
 			name: "pre-role"
 			labels:
-				app: "pre-role"
 				app.kubernetes.io/component: pre-role
 				app.kubernetes.io/instance: MyRelease
 				app.kubernetes.io/managed-by: Tiller
@@ -2077,7 +2070,6 @@ func TestPodMemoryHelmActive(t *testing.T) {
 				app.kubernetes.io/version: 1.22.333.4444
 				helm.sh/chart: MyChart-42.1_foo
 				skiff-role-name: "pre-role"
-				version: 1.22.333.4444
 		spec:
 			containers:
 			-	env:
@@ -2201,7 +2193,6 @@ func TestPodCPUHelmDisabled(t *testing.T) {
 		metadata:
 			name: "pre-role"
 			labels:
-				app: "pre-role"
 				app.kubernetes.io/component: pre-role
 				app.kubernetes.io/instance: MyRelease
 				app.kubernetes.io/managed-by: Tiller
@@ -2209,7 +2200,6 @@ func TestPodCPUHelmDisabled(t *testing.T) {
 				app.kubernetes.io/version: 1.22.333.4444
 				helm.sh/chart: MyChart-42.1_foo
 				skiff-role-name: "pre-role"
-				version: 1.22.333.4444
 		spec:
 			containers:
 			-	env:
@@ -2294,7 +2284,6 @@ func TestPodCPUHelmActive(t *testing.T) {
 		metadata:
 			name: "pre-role"
 			labels:
-				app: "pre-role"
 				app.kubernetes.io/component: pre-role
 				app.kubernetes.io/instance: MyRelease
 				app.kubernetes.io/managed-by: Tiller
@@ -2302,7 +2291,6 @@ func TestPodCPUHelmActive(t *testing.T) {
 				app.kubernetes.io/version: 1.22.333.4444
 				helm.sh/chart: MyChart-42.1_foo
 				skiff-role-name: "pre-role"
-				version: 1.22.333.4444
 		spec:
 			containers:
 			-	env:

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -105,7 +105,6 @@ func TestServiceHelm(t *testing.T) {
 			metadata:
 				name: "myrole-tor"
 				labels:
-					app: "myrole-tor"
 					app.kubernetes.io/component: myrole-tor
 					app.kubernetes.io/instance: MyRelease
 					app.kubernetes.io/managed-by: Tiller
@@ -142,7 +141,6 @@ func TestServiceHelm(t *testing.T) {
 			metadata:
 				name: "myrole-tor"
 				labels:
-					app: "myrole-tor"
 					app.kubernetes.io/component: myrole-tor
 					app.kubernetes.io/instance: MyRelease
 					app.kubernetes.io/managed-by: Tiller
@@ -178,7 +176,6 @@ func TestServiceHelm(t *testing.T) {
 			metadata:
 				name: "myrole-tor"
 				labels:
-					app: "myrole-tor"
 					app.kubernetes.io/component: myrole-tor
 					app.kubernetes.io/instance: MyRelease
 					app.kubernetes.io/managed-by: Tiller
@@ -408,7 +405,6 @@ func TestHeadlessServiceHelm(t *testing.T) {
 			metadata:
 				name: "myservice-set"
 				labels:
-					app: "myservice-set"
 					app.kubernetes.io/component: myservice-set
 					app.kubernetes.io/instance: MyRelease
 					app.kubernetes.io/managed-by: Tiller
@@ -446,7 +442,6 @@ func TestHeadlessServiceHelm(t *testing.T) {
 			metadata:
 				name: "myservice-set"
 				labels:
-					app: "myservice-set"
 					app.kubernetes.io/component: myservice-set
 					app.kubernetes.io/instance: MyRelease
 					app.kubernetes.io/managed-by: Tiller
@@ -483,7 +478,6 @@ func TestHeadlessServiceHelm(t *testing.T) {
 			metadata:
 				name: "myservice-set"
 				labels:
-					app: "myservice-set"
 					app.kubernetes.io/component: myservice-set
 					app.kubernetes.io/instance: MyRelease
 					app.kubernetes.io/managed-by: Tiller
@@ -574,7 +568,6 @@ func TestPublicServiceHelm(t *testing.T) {
 			metadata:
 				name: "myrole-tor-public"
 				labels:
-					app: "myrole-tor-public"
 					app.kubernetes.io/component: myrole-tor-public
 					app.kubernetes.io/instance: MyRelease
 					app.kubernetes.io/managed-by: Tiller
@@ -609,7 +602,6 @@ func TestPublicServiceHelm(t *testing.T) {
 			metadata:
 				name: "myrole-tor-public"
 				labels:
-					app: "myrole-tor-public"
 					app.kubernetes.io/component: myrole-tor-public
 					app.kubernetes.io/instance: MyRelease
 					app.kubernetes.io/managed-by: Tiller
@@ -656,7 +648,6 @@ func TestPublicServiceHelm(t *testing.T) {
 			metadata:
 				name: "myrole-tor-public"
 				labels:
-					app: "myrole-tor-public"
 					app.kubernetes.io/component: myrole-tor-public
 					app.kubernetes.io/instance: MyRelease
 					app.kubernetes.io/managed-by: Tiller
@@ -757,7 +748,6 @@ func TestActivePassiveService(t *testing.T) {
 											metadata:
 												name: myrole-set
 												labels:
-													app: "myrole-set"
 													app.kubernetes.io/component: myrole-set
 													app.kubernetes.io/instance: MyRelease
 													app.kubernetes.io/managed-by: Tiller
@@ -794,7 +784,6 @@ func TestActivePassiveService(t *testing.T) {
 											metadata:
 												name: myrole-tor-set
 												labels:
-													app: "myrole-tor-set"
 													app.kubernetes.io/component: myrole-tor-set
 													app.kubernetes.io/instance: MyRelease
 													app.kubernetes.io/managed-by: Tiller
@@ -836,7 +825,6 @@ func TestActivePassiveService(t *testing.T) {
 										metadata:
 											name: myrole-tor
 											labels:
-												app: "myrole-tor"
 												app.kubernetes.io/component: myrole-tor
 												app.kubernetes.io/instance: MyRelease
 												app.kubernetes.io/managed-by: Tiller
@@ -873,7 +861,6 @@ func TestActivePassiveService(t *testing.T) {
 										metadata:
 											name: myrole-tor-public
 											labels:
-												app: "myrole-tor-public"
 												app.kubernetes.io/component: myrole-tor-public
 												app.kubernetes.io/instance: MyRelease
 												app.kubernetes.io/managed-by: Tiller
@@ -913,7 +900,6 @@ func TestActivePassiveService(t *testing.T) {
 
 func expectedYAML(settings ExportSettings, expected string) string {
 	if !settings.CreateHelmChart {
-		expected = regexp.MustCompile("app: .*").ReplaceAllLiteralString(expected, "")
 		expected = regexp.MustCompile("app.kubernetes.io/instance: .*").ReplaceAllLiteralString(expected, "")
 		expected = regexp.MustCompile("app.kubernetes.io/managed-by: .*").ReplaceAllLiteralString(expected, "")
 		expected = regexp.MustCompile("app.kubernetes.io/name: .*").ReplaceAllLiteralString(expected, "")

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -123,7 +123,7 @@ func MakeBasicValues() *helm.Mapping {
 				"requests", helm.NewNode(false, helm.Comment("Flag to activate cpu requests")),
 				"limits", helm.NewNode(false, helm.Comment("Flag to activate cpu limits")),
 			), helm.Comment("Global CPU configuration")),
-			"use_istio", helm.NewNode(true, helm.Comment("Flag to specify whether to add Istio related annotations and labels"))),
+			"use_istio", helm.NewNode(false, helm.Comment("Flag to specify whether to add Istio related annotations and labels"))),
 		"bosh", helm.NewMapping("instance_groups", helm.NewList()),
 		"env", helm.NewMapping(),
 		"sizing", helm.NewMapping(),

--- a/kube/utils_test.go
+++ b/kube/utils_test.go
@@ -60,8 +60,10 @@ func TestNewSelectorIstioManaged(t *testing.T) {
 	role := makeTemplateRole()
 	settings := ExportSettings{CreateHelmChart: true}
 	selector := newSelector(role, settings)
-
-	actual, err := RoundtripNode(selector, nil)
+	config := map[string]interface{}{
+		"Values.config.use_istio": true,
+	}
+	actual, err := RoundtripNode(selector, config)
 	if !assert.NoError(err) {
 		return
 	}


### PR DESCRIPTION
It should not matter because older role manifest should not have the "istio-managed" tag on any of their roles, but it seems cleaner to not generate the istio related labels and annotations at all unless explicitly asked for.

This is a followup to #457. After followup discussion we decided to play it safe and change the default value to maximum backwards compatibility. (fyi @zhanggbj)