### PR TITLE
Resolver: remove warning message about things needing escalation

### DIFF
--- a/model/resolver/resolver.go
+++ b/model/resolver/resolver.go
@@ -2,7 +2,6 @@ package resolver
 
 import (
 	"fmt"
-	"sort"
 
 	"code.cloudfoundry.org/fissile/model"
 	"code.cloudfoundry.org/fissile/util"
@@ -470,12 +469,6 @@ func resolvePodSecurityPolicies(m *model.RoleManifest) validation.ErrorList {
 	if len(instanceGroupsNeedingEscalation) < 1 {
 		return errors
 	}
-	instanceGroupNames := make([]string, 0, len(instanceGroupsNeedingEscalation))
-	for i := range instanceGroupsNeedingEscalation {
-		instanceGroupNames = append(instanceGroupNames, m.InstanceGroups[i].Name)
-	}
-	sort.Strings(instanceGroupNames)
-	fmt.Printf("Found %d instance groups requiring escalation: %s\n", len(instanceGroupsNeedingEscalation), instanceGroupNames)
 
 	// Find a PSP to use as the privileged PSP
 	defaultPrivilegedPSPName := "privileged"


### PR DESCRIPTION
Turns out we can't have any extra messages because we sometime process the output (e.g. `fissile show images`), and having extra things breaks that.