### PR TITLE
Make final releases dir configurable

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -96,10 +96,11 @@ func (f *Fissile) LoadManifest() error {
 		f.Options.RoleManifest,
 		model.LoadRoleManifestOptions{
 			ReleaseOptions: model.ReleaseOptions{
-				ReleasePaths:    f.Options.Releases,
-				ReleaseNames:    f.Options.ReleaseNames,
-				ReleaseVersions: f.Options.ReleaseVersions,
-				BOSHCacheDir:    f.Options.CacheDir,
+				ReleasePaths:     f.Options.Releases,
+				ReleaseNames:     f.Options.ReleaseNames,
+				ReleaseVersions:  f.Options.ReleaseVersions,
+				BOSHCacheDir:     f.Options.CacheDir,
+				FinalReleasesDir: f.Options.FinalReleasesDir,
 			},
 			Grapher: f,
 		},

--- a/app/fissile_test.go
+++ b/app/fissile_test.go
@@ -354,8 +354,9 @@ func TestGenerateAuth(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/app/generate-auth.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 		Grapher: f})
 	require.NoError(t, err)
 	require.NotNil(t, roleManifest)

--- a/builder/packages_image_test.go
+++ b/builder/packages_image_test.go
@@ -97,8 +97,9 @@ func TestNewDockerPopulator(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/builder/tor-good.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{releasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+			ReleasePaths:     []string{releasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -220,8 +221,9 @@ func TestGetRolePackageImageName(t *testing.T) {
 	roleManifestPath := filepath.Join(roleManifestDir, "tor-good.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{releasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+			ReleasePaths:     []string{releasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -315,8 +317,9 @@ func TestGetRolePackageImageName(t *testing.T) {
 		assert.NoError(t, ioutil.WriteFile(tempManifestFile.Name(), yamlBytes, 0644), "Error writing modified role manifest")
 		modifiedRoleManifest, err := loader.LoadRoleManifest(tempManifestFile.Name(), model.LoadRoleManifestOptions{
 			ReleaseOptions: model.ReleaseOptions{
-				ReleasePaths: []string{releasePath},
-				BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+				ReleasePaths:     []string{releasePath},
+				BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+				FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 			ValidationOptions: model.RoleManifestValidationOptions{
 				AllowMissingScripts: true,
 			}})

--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -50,8 +50,9 @@ func TestGenerateRoleImageDockerfile(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/builder/tor-good.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{releasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+			ReleasePaths:     []string{releasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -94,8 +95,9 @@ func TestGenerateRoleImageRunScript(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/builder/tor-good.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{releasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+			ReleasePaths:     []string{releasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -157,8 +159,9 @@ func TestGenerateRoleImageJobsConfig(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/builder/tor-good.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{releasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+			ReleasePaths:     []string{releasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -196,8 +199,9 @@ func TestGenerateRoleImageDockerfileDir(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/builder/tor-good.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{releasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+			ReleasePaths:     []string{releasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -415,8 +419,10 @@ func TestBuildRoleImages(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/builder/tor-good.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{releasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")}})
+			ReleasePaths:     []string{releasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases"),
+		}})
 	assert.NoError(err)
 	torOpinionsDir := filepath.Join(workDir, "../test-assets/tor-opinions")
 	lightOpinionsPath := filepath.Join(torOpinionsDir, "opinions.yml")

--- a/compilator/compilator_test.go
+++ b/compilator/compilator_test.go
@@ -194,8 +194,9 @@ func TestCompilationRoleManifest(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/compilator/tor-good.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{releasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+			ReleasePaths:     []string{releasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})

--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -20,8 +20,9 @@ func deploymentTestLoad(assert *assert.Assertions, roleName, manifestName string
 	releasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
 	manifest, err := loader.LoadRoleManifest(manifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{releasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+			ReleasePaths:     []string{releasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})

--- a/kube/job_test.go
+++ b/kube/job_test.go
@@ -19,8 +19,9 @@ func jobTestLoadRole(assert *assert.Assertions, roleName, manifestName string) *
 	releasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
 	manifest, err := loader.LoadRoleManifest(manifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{releasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+			ReleasePaths:     []string{releasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -26,8 +26,9 @@ func podTemplateTestLoadRole(assert *assert.Assertions) *model.InstanceGroup {
 	releasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
 	manifest, err := loader.LoadRoleManifest(manifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{releasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+			ReleasePaths:     []string{releasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -1639,8 +1640,9 @@ func podTestLoadRoleFrom(assert *assert.Assertions, roleName, manifestName strin
 	releasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
 	manifest, err := loader.LoadRoleManifest(manifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{releasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+			ReleasePaths:     []string{releasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -2780,8 +2782,9 @@ func TestPodVolumeTypeEmptyDir(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/kube/colocated-containers.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{torReleasePath, ntpReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath, ntpReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -23,8 +23,9 @@ func serviceTestLoadRole(assert *assert.Assertions, manifestName string) (*model
 	releasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
 	manifest, err := loader.LoadRoleManifest(manifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{releasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+			ReleasePaths:     []string{releasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -22,8 +22,9 @@ func statefulSetTestLoadManifest(assert *assert.Assertions, manifestName string)
 	releasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
 	manifest, err := loader.LoadRoleManifest(manifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{releasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../test-assets/bosh-cache")},
+			ReleasePaths:     []string{releasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})

--- a/model/release_resolver.go
+++ b/model/release_resolver.go
@@ -2,10 +2,11 @@ package model
 
 // ReleaseOptions for releases
 type ReleaseOptions struct {
-	ReleasePaths    []string
-	ReleaseNames    []string
-	ReleaseVersions []string
-	BOSHCacheDir    string
+	ReleasePaths     []string
+	ReleaseNames     []string
+	ReleaseVersions  []string
+	BOSHCacheDir     string
+	FinalReleasesDir string
 }
 
 // ReleaseResolver loads job specs from releases and acts as a registry for

--- a/model/releaseresolver/load_releases.go
+++ b/model/releaseresolver/load_releases.go
@@ -66,7 +66,7 @@ func isFinalReleasePath(releasePath string) (bool, error) {
 
 // downloadReleaseReferences downloads/builds and loads releases referenced in the
 // manifest
-func downloadReleaseReferences(releaseRefs []*model.ReleaseRef, manifestPath string) ([]*model.Release, error) {
+func downloadReleaseReferences(releaseRefs []*model.ReleaseRef, finalReleasesDir string) ([]*model.Release, error) {
 	releases := []*model.Release{}
 
 	var allErrs error
@@ -87,13 +87,11 @@ func downloadReleaseReferences(releaseRefs []*model.ReleaseRef, manifestPath str
 				return
 			}
 			// this is a final release that we need to download
-			manifestDir := filepath.Dir(manifestPath)
-			finalReleasesWorkDir := filepath.Join(manifestDir, ".final_releases")
 			finalReleaseTarballPath := filepath.Join(
-				finalReleasesWorkDir,
+				finalReleasesDir,
 				fmt.Sprintf("%s-%s-%s.tgz", releaseRef.Name, releaseRef.Version, releaseRef.SHA1))
 			finalReleaseUnpackedPath := filepath.Join(
-				finalReleasesWorkDir,
+				finalReleasesDir,
 				fmt.Sprintf("%s-%s-%s", releaseRef.Name, releaseRef.Version, releaseRef.SHA1))
 
 			if _, err := os.Stat(filepath.Join(finalReleaseUnpackedPath, "release.MF")); err != nil && os.IsNotExist(err) {
@@ -141,10 +139,8 @@ func downloadReleaseReferences(releaseRefs []*model.ReleaseRef, manifestPath str
 	// Now that all releases have been downloaded and unpacked,
 	// add them to the collection
 	for _, releaseRef := range releaseRefs {
-		manifestDir := filepath.Dir(manifestPath)
-		finalReleasesWorkDir := filepath.Join(manifestDir, ".final_releases")
 		finalReleaseUnpackedPath := filepath.Join(
-			finalReleasesWorkDir,
+			finalReleasesDir,
 			fmt.Sprintf("%s-%s-%s", releaseRef.Name, releaseRef.Version, releaseRef.SHA1))
 
 		// create a release object and add it to the collection

--- a/model/releaseresolver/release_resolver.go
+++ b/model/releaseresolver/release_resolver.go
@@ -26,7 +26,7 @@ func (r *ReleaseResolver) Load(options model.ReleaseOptions, releaseRefs []*mode
 		return nil, err
 	}
 
-	embeddedReleases, err := downloadReleaseReferences(releaseRefs, r.manifestPath)
+	embeddedReleases, err := downloadReleaseReferences(releaseRefs, options.FinalReleasesDir)
 	if err != nil {
 		return nil, err
 	}

--- a/model/resolver/resolve_role_manifest_test.go
+++ b/model/resolver/resolve_role_manifest_test.go
@@ -54,10 +54,11 @@ func TestRoleManifestTagList(t *testing.T) {
 	torReleasePath := filepath.Join(workDir, "../../test-assets/tor-boshrelease")
 	releases, err := releaseresolver.LoadReleasesFromDisk(
 		ReleaseOptions{
-			ReleasePaths:    []string{torReleasePath},
-			ReleaseNames:    []string{},
-			ReleaseVersions: []string{},
-			BOSHCacheDir:    filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			ReleasePaths:     []string{torReleasePath},
+			ReleaseNames:     []string{},
+			ReleaseVersions:  []string{},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases"),
 		})
 	require.NoError(t, err, "Error reading BOSH release")
 

--- a/model/resolver/resolver_test.go
+++ b/model/resolver/resolver_test.go
@@ -21,10 +21,11 @@ func TestLoadRoleManifestOK(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/tor-good.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths:    []string{torReleasePath},
-			ReleaseNames:    []string{},
-			ReleaseVersions: []string{},
-			BOSHCacheDir:    filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			ReleasePaths:     []string{torReleasePath},
+			ReleaseNames:     []string{},
+			ReleaseVersions:  []string{},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases"),
 		},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
@@ -56,8 +57,9 @@ func TestScriptPathInvalid(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/script-bad-prefix.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")}})
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")}})
 	require.Error(t, err, "invalid role manifest should return error")
 	assert.Nil(t, roleManifest, "invalid role manifest loaded")
 	for _, msg := range []string{
@@ -89,8 +91,9 @@ func TestLoadRoleManifestNotOKBadJobName(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/tor-bad.yml")
 	_, err = loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")}})
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")}})
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Cannot find job foo in release")
 	}
@@ -104,8 +107,9 @@ func TestLoadDuplicateReleases(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/tor-good.yml")
 	_, err = loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath, torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")}})
+			ReleasePaths:     []string{torReleasePath, torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")}})
 
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "release tor has been loaded more than once")
@@ -121,8 +125,9 @@ func TestLoadRoleManifestMultipleReleasesOK(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/multiple-good.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath, ntpReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath, ntpReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -153,8 +158,9 @@ func TestLoadRoleManifestMultipleReleasesNotOk(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/multiple-bad.yml")
 	_, err = loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath, ntpReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")}})
+			ReleasePaths:     []string{torReleasePath, ntpReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")}})
 
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(),
@@ -170,8 +176,9 @@ func TestNonBoshRolesAreNotAllowed(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/non-bosh-roles.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")}})
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")}})
 	assert.EqualError(t, err, "instance_groups[dockerrole].type: Invalid value: \"docker\": Expected one of bosh, bosh-task, or colocated-container")
 	assert.Nil(t, roleManifest)
 }
@@ -184,8 +191,9 @@ func TestLoadRoleManifestVariablesSortedError(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/variables-badly-sorted.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")}})
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")}})
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), `variables: Invalid value: "FOO": Does not sort before 'BAR'`)
@@ -203,8 +211,9 @@ func TestLoadRoleManifestVariablesPreviousNamesError(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/variables-with-dup-prev-names.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")}})
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")}})
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), `variables: Invalid value: "FOO": Previous name 'BAR' also exist as a new variable`)
@@ -222,8 +231,9 @@ func TestLoadRoleManifestVariablesNotUsed(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/variables-without-usage.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -240,8 +250,9 @@ func TestLoadRoleManifestVariablesNotDeclared(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/variables-without-decl.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -258,8 +269,9 @@ func TestLoadRoleManifestVariablesSSH(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/variables-ssh.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -276,8 +288,9 @@ func TestLoadRoleManifestNonTemplates(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/templates-non.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -294,8 +307,9 @@ func TestLoadRoleManifestBadType(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/bad-type.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -315,8 +329,9 @@ func TestLoadRoleManifestBadCVType(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/bad-cv-type.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -334,8 +349,9 @@ func TestLoadRoleManifestBadCVTypeConflictInternal(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/bad-cv-type-internal.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -352,8 +368,9 @@ func TestLoadRoleManifestMissingRBACAccount(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/rbac-missing-account.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")}})
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")}})
 	assert.EqualError(t, err, `instance_groups[myrole].run.service-account: Not found: "missing-account"`)
 	assert.Nil(t, roleManifest)
 }
@@ -366,8 +383,9 @@ func TestLoadRoleManifestMissingRBACRole(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/rbac-missing-role.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -385,8 +403,9 @@ func TestLoadRoleManifestPSPMerge(t *testing.T) {
 		"../../test-assets/role-manifests/model/rbac-merge-psp.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -464,8 +483,9 @@ func TestLoadRoleManifestSACloneForPSPMismatch(t *testing.T) {
 		"../../test-assets/role-manifests/model/rbac-clone-sa-psp-mismatch.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -605,8 +625,9 @@ func TestLoadRoleManifestRunGeneral(t *testing.T) {
 				roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model", tc.manifest)
 				roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 					ReleaseOptions: ReleaseOptions{
-						ReleasePaths: []string{torReleasePath},
-						BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+						ReleasePaths:     []string{torReleasePath},
+						BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+						FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 					ValidationOptions: RoleManifestValidationOptions{
 						AllowMissingScripts: true,
 					}})
@@ -637,8 +658,9 @@ func TestResolveLinks(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/multiple-good.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: releasePaths,
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     releasePaths,
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -900,8 +922,9 @@ func TestLoadRoleManifestColocatedContainers(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/colocated-containers.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath, ntpReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath, ntpReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -929,8 +952,9 @@ func TestLoadRoleManifestColocatedContainersValidationMissingRole(t *testing.T) 
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/colocated-containers-with-missing-role.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath, ntpReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")}})
+			ReleasePaths:     []string{torReleasePath, ntpReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")}})
 	assert.Nil(roleManifest)
 	assert.EqualError(err, `instance_groups[main-role].colocated_containers[0]: Invalid value: "to-be-colocated-typo": There is no such instance group defined`)
 }
@@ -946,8 +970,9 @@ func TestLoadRoleManifestColocatedContainersValidationUsusedRole(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/colocated-containers-with-unused-role.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath, ntpReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath, ntpReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -968,8 +993,9 @@ func TestLoadRoleManifestColocatedContainersValidationPortCollisions(t *testing.
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/colocated-containers-with-port-collision.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath, ntpReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath, ntpReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -989,8 +1015,9 @@ func TestLoadRoleManifestColocatedContainersValidationPortCollisionsWithProtocol
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/colocated-containers-with-no-port-collision.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath, ntpReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath, ntpReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -1025,8 +1052,9 @@ func TestLoadRoleManifestColocatedContainersValidationOfSharedVolumes(t *testing
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/colocated-containers-with-volume-share-issues.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			ReleasePaths: []string{torReleasePath, ntpReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath, ntpReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -1043,7 +1071,8 @@ func TestLoadRoleManifestWithReleaseReferences(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/online-release-references.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
 		ReleaseOptions: ReleaseOptions{
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})

--- a/model/resolver/validation_test.go
+++ b/model/resolver/validation_test.go
@@ -20,8 +20,9 @@ func TestGetScriptPaths(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/tor-good.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})
@@ -43,8 +44,9 @@ func TestRoleVariables(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/variable-expansion.yml")
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})

--- a/model/resolver/variables_test.go
+++ b/model/resolver/variables_test.go
@@ -20,8 +20,9 @@ func TestLoadDeploymentManifestVariables(t *testing.T) {
 
 	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, model.LoadRoleManifestOptions{
 		ReleaseOptions: model.ReleaseOptions{
-			ReleasePaths: []string{torReleasePath},
-			BOSHCacheDir: filepath.Join(workDir, "../../test-assets/bosh-cache")},
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
 		ValidationOptions: model.RoleManifestValidationOptions{
 			AllowMissingScripts: true,
 		}})


### PR DESCRIPTION
fissile already has a `--final-releases-dir` option, but the value was not used at all.  This commit passes it through to `downloadReleaseReferences()`, so final releases are no longer put next to the role manifest directory.

The default for `--final-releases-dir` is `~/.final-releases`.

[#162255302]