### PR TITLE
Restricted kube object name sizes.

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -763,9 +763,23 @@ func (f *Fissile) GenerateKube(settings kube.ExportSettings) error {
 		if err != nil {
 			return err
 		}
+
+		err = f.generateHelmHelpers("_fissileHelpers.yaml", settings)
+		if err != nil {
+			return err
+		}
 	}
 
 	return f.generateKubeRoles(settings)
+}
+
+// generateHelmHelpers will write out helm helper files.
+func (f *Fissile) generateHelmHelpers(fileName string, settings kube.ExportSettings) error {
+	if !settings.CreateHelmChart {
+		panic("generateHelmHelpers called when not generating helm chart")
+	}
+	outputDir := filepath.Join(settings.OutputDir, "templates")
+	return f.writeHelmNode(outputDir, fileName, kube.GetHelmTemplateHelpers()...)
 }
 
 func (f *Fissile) generateSecrets(fileName string, secrets helm.Node, settings kube.ExportSettings) error {

--- a/kube/bosh_deployment_manifest_secret.go
+++ b/kube/bosh_deployment_manifest_secret.go
@@ -1,6 +1,10 @@
 package kube
 
-import "code.cloudfoundry.org/fissile/helm"
+import (
+	"fmt"
+
+	"code.cloudfoundry.org/fissile/helm"
+)
 
 // MakeBoshDeploymentManifestSecret generates a template for a secret that holds the content of a BOSH deployment manifest
 func MakeBoshDeploymentManifestSecret(settings ExportSettings) (helm.Node, error) {
@@ -9,7 +13,15 @@ func MakeBoshDeploymentManifestSecret(settings ExportSettings) (helm.Node, error
 		value = "{{ .Values.bosh | toYaml | b64enc }}"
 	}
 
-	secret := newKubeConfig(settings, "v1", "Secret", "deployment-manifest")
+	cb := NewConfigBuilder().
+		SetSettings(&settings).
+		SetAPIVersion("v1").
+		SetKind("Secret").
+		SetName("deployment-manifest")
+	secret, err := cb.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build a new kube config: %v", err)
+	}
 
 	data := helm.NewMapping("deployment-manifest", value)
 	secret.Add("data", data)

--- a/kube/job.go
+++ b/kube/job.go
@@ -30,7 +30,16 @@ func NewJob(instanceGroup *model.InstanceGroup, settings ExportSettings, grapher
 		name += "-{{ .Release.Revision }}"
 	}
 
-	job := newKubeConfig(settings, "batch/v1", "Job", name, helm.Comment(instanceGroup.GetLongDescription()))
+	cb := NewConfigBuilder().
+		SetSettings(&settings).
+		SetAPIVersion("batch/v1").
+		SetKind("Job").
+		SetName(name).
+		AddModifier(helm.Comment(instanceGroup.GetLongDescription()))
+	job, err := cb.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build a new kube config: %v", err)
+	}
 	job.Add("spec", helm.NewMapping("template", podTemplate))
 
 	return job.Sort(), nil

--- a/kube/kube_test.go
+++ b/kube/kube_test.go
@@ -95,10 +95,6 @@ func RenderNode(node helm.Node, config interface{}) ([]byte, error) {
 
 	// Note: Replicate helm's behaviour on missing keys.
 	tmpl := template.New("").Option("missingkey=zero").Funcs(functions)
-	if err != nil {
-		//fmt.Printf("TEMPLATE SETUP FAIL: %s", err)
-		return nil, err
-	}
 
 	tmpl, err = tmpl.Parse(string(helmHelpers.Bytes()))
 	if err != nil {

--- a/kube/kube_test.go
+++ b/kube/kube_test.go
@@ -68,13 +68,19 @@ func RenderNode(node helm.Node, config interface{}) ([]byte, error) {
 		return nil, fmt.Errorf("Invalid config %+v", config)
 	}
 
-	var helmConfig, yamlConfig bytes.Buffer
+	var helmConfig, yamlConfig, helmHelpers bytes.Buffer
 
 	if node == nil {
 		node = helm.NewNode(nil)
 	}
 	if err := helm.NewEncoder(&helmConfig).Encode(node); err != nil {
 		return nil, err
+	}
+
+	for _, helper := range GetHelmTemplateHelpers() {
+		if err := helm.NewEncoder(&helmHelpers).Encode(helper); err != nil {
+			return nil, err
+		}
 	}
 
 	// The functions added here are implementations of the helm
@@ -88,12 +94,24 @@ func RenderNode(node helm.Node, config interface{}) ([]byte, error) {
 	functions["toYaml"] = renderToYaml
 
 	// Note: Replicate helm's behaviour on missing keys.
-	tmpl, err := template.New("").Option("missingkey=zero").Funcs(functions).Parse(string(helmConfig.Bytes()))
+	tmpl := template.New("").Option("missingkey=zero").Funcs(functions)
+	if err != nil {
+		//fmt.Printf("TEMPLATE SETUP FAIL: %s", err)
+		return nil, err
+	}
 
+	tmpl, err = tmpl.Parse(string(helmHelpers.Bytes()))
+	if err != nil {
+		//fmt.Printf("HELPER PARSE FAIL: %s\n%s\nPARSE END\n", err, string(helmHelpers.Bytes()))
+		return nil, err
+	}
+
+	tmpl, err = tmpl.Parse(string(helmConfig.Bytes()))
 	if err != nil {
 		//fmt.Printf("TEMPLATE PARSE FAIL: %s\n%s\nPARSE END\n", err, string(helmConfig.Bytes()))
 		return nil, err
 	}
+
 	if err = tmpl.Execute(&yamlConfig, actualConfig); err != nil {
 		//fmt.Printf("TEMPLATE EXEC FAIL\n%s\n%s\nEXEC END\n", string(helmConfig.Bytes()), err)
 		return nil, err
@@ -111,6 +129,7 @@ func RoundtripNode(node helm.Node, config interface{}) (interface{}, error) {
 
 	var actual interface{}
 	if err := yaml.Unmarshal(actualBytes, &actual); err != nil {
+		//fmt.Printf("YAML UNMARSHAL ERROR\n%s\n", string(actualBytes))
 		return nil, err
 	}
 	return actual, nil

--- a/kube/rbac.go
+++ b/kube/rbac.go
@@ -56,11 +56,11 @@ func NewRBACAccount(accountName string, config *model.Configuration, settings Ex
 			SetName(accountName).
 			AddModifier(block).
 			AddModifier(helm.Comment(description))
-		resource, err := cb.Build()
+		serviceAccount, err := cb.Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build a new kube config: %v", err)
 		}
-		resources = append(resources, resource)
+		resources = append(resources, serviceAccount)
 	}
 
 	// For each role, create a role binding
@@ -138,7 +138,6 @@ func NewRBACAccount(accountName string, config *model.Configuration, settings Ex
 			SetSettings(&settings).
 			SetAPIVersion("rbac.authorization.k8s.io/v1").
 			SetKind("ClusterRoleBinding").
-			SetName(fmt.Sprintf("%s-%s-cluster-binding", accountName, clusterRoleName)).
 			AddModifier(block).
 			AddModifier(helm.Comment(fmt.Sprintf(`Cluster role binding for service account "%s" and cluster role "%s"`,
 				accountName,
@@ -148,6 +147,8 @@ func NewRBACAccount(accountName string, config *model.Configuration, settings Ex
 				fmt.Sprintf(`{{ template "fissile.SanitizeName" (printf "%%s-%s-%s-cluster-binding" .Release.Namespace) }}`,
 					accountName,
 					clusterRoleName))
+		} else {
+			cb.SetName(fmt.Sprintf("%s-%s-cluster-binding", accountName, clusterRoleName))
 		}
 		binding, err := cb.Build()
 		if err != nil {

--- a/kube/registry_credentials.go
+++ b/kube/registry_credentials.go
@@ -1,6 +1,8 @@
 package kube
 
 import (
+	"fmt"
+
 	"code.cloudfoundry.org/fissile/helm"
 )
 
@@ -30,7 +32,15 @@ func MakeRegistryCredentials(settings ExportSettings) (helm.Node, error) {
 
 	data := helm.NewMapping(".dockercfg", value)
 
-	secret := newKubeConfig(settings, "v1", "Secret", "registry-credentials")
+	cb := NewConfigBuilder().
+		SetSettings(&settings).
+		SetAPIVersion("v1").
+		SetKind("Secret").
+		SetName("registry-credentials")
+	secret, err := cb.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build a new kube config: %v", err)
+	}
 	secret.Add("data", data)
 	secret.Add("type", "kubernetes.io/dockercfg")
 

--- a/kube/secret.go
+++ b/kube/secret.go
@@ -54,7 +54,15 @@ func MakeSecrets(secrets model.CVMap, settings ExportSettings) (helm.Node, error
 	data.Sort()
 	data.Merge(generated.Sort())
 
-	secret := newKubeConfig(settings, "v1", "Secret", userSecretsName)
+	cb := NewConfigBuilder().
+		SetSettings(&settings).
+		SetAPIVersion("v1").
+		SetKind("Secret").
+		SetName(userSecretsName)
+	secret, err := cb.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build a new kube config: %v", err)
+	}
 	secret.Add("data", data)
 
 	return secret.Sort(), nil

--- a/kube/service.go
+++ b/kube/service.go
@@ -172,7 +172,15 @@ func newClusteringService(role *model.InstanceGroup, settings ExportSettings) (h
 	spec.Add("clusterIP", "None")
 	spec.Add("ports", helm.NewNode(ports))
 
-	service := newKubeConfig(settings, "v1", "Service", role.Name+"-set")
+	cb := NewConfigBuilder().
+		SetSettings(&settings).
+		SetAPIVersion("v1").
+		SetKind("Service").
+		SetName(fmt.Sprintf("%s-set", role.Name))
+	service, err := cb.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build a new kube config: %v", err)
+	}
 	service.Add("spec", spec.Sort())
 
 	return service, nil
@@ -237,7 +245,15 @@ func newService(role *model.InstanceGroup, job *model.JobReference, serviceType 
 		panic(fmt.Sprintf("Unexpected service type %d", serviceType))
 	}
 
-	service := newKubeConfig(settings, "v1", "Service", serviceName)
+	cb := NewConfigBuilder().
+		SetSettings(&settings).
+		SetAPIVersion("v1").
+		SetKind("Service").
+		SetName(serviceName)
+	service, err := cb.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build a new kube config: %v", err)
+	}
 	service.Add("spec", spec.Sort())
 
 	if settings.CreateHelmChart && serviceType == newServiceTypePublic {

--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -47,7 +47,16 @@ func NewStatefulSet(role *model.InstanceGroup, settings ExportSettings, grapher 
 	}
 	spec.Add("podManagementPolicy", podManagementPolicy)
 
-	statefulSet := newKubeConfig(settings, "apps/v1beta1", "StatefulSet", role.Name, helm.Comment(role.GetLongDescription()))
+	cb := NewConfigBuilder().
+		SetSettings(&settings).
+		SetAPIVersion("apps/v1beta1").
+		SetKind("StatefulSet").
+		SetName(role.Name).
+		AddModifier(helm.Comment(role.GetLongDescription()))
+	statefulSet, err := cb.Build()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build a new kube config: %v", err)
+	}
 	statefulSet.Add("spec", spec)
 	err = replicaCheck(role, statefulSet, svcList, settings)
 	if err != nil {

--- a/kube/templates.go
+++ b/kube/templates.go
@@ -1,26 +1,26 @@
 package kube
 
 import (
-	"regexp"
+	"strings"
 
 	"code.cloudfoundry.org/fissile/helm"
 )
 
 // GetHelmTemplateHelpers returns the helm templates needed throughout the code.
 func GetHelmTemplateHelpers() []helm.Node {
-	sanitizeNameHelper := `
-		{{ define "fissile.SanitizeName" }}
-			{{ if lt (len .) 1 }}{{ fail "No name given for node" }}{{ end }}
-			{{ if gt (len .) 63 }}
-				{{ . | trunc 54 }}-{{ . | sha256sum | trunc 8 }}
-			{{ else }}
-				{{ . }}
-			{{ end }}
-		{{ end }}`
+	sanitizeNameHelper := []string{
+		`{{ define "fissile.SanitizeName" }}`,
+		`    {{- if lt (len .) 1 }}{{ fail "No name given for node" }}{{ end }}`,
+		`    {{- if gt (len .) 63 }}`,
+		`        {{- . | trunc 54 }}-{{ . | sha256sum | trunc 8 }}`,
+		`    {{- else }}`,
+		`        {{- . }}`,
+		`    {{- end }}`,
+		`{{ end }}`,
+	}
 	return []helm.Node{
 		helm.NewNode(
-			regexp.MustCompile(`(^|\}\})\s+(\{\{|$)`).
-				ReplaceAllString(sanitizeNameHelper, "${1}${2}"),
+			strings.Join(sanitizeNameHelper, ""),
 			helm.Comment(`
 				fissile.SanitizeName returns the given parameter, up to 63 characters long.
 				This should be called as {{ template "fissile.SanitizeName" "foo" }}

--- a/kube/templates.go
+++ b/kube/templates.go
@@ -1,0 +1,29 @@
+package kube
+
+import (
+	"regexp"
+
+	"code.cloudfoundry.org/fissile/helm"
+)
+
+// GetHelmTemplateHelpers returns the helm templates needed throughout the code.
+func GetHelmTemplateHelpers() []helm.Node {
+	sanitizeNameHelper := `
+		{{ define "fissile.SanitizeName" }}
+			{{ if lt (len .) 1 }}{{ fail "No name given for node" }}{{ end }}
+			{{ if gt (len .) 63 }}
+				{{ . | trunc 54 }}-{{ . | sha256sum | trunc 8 }}
+			{{ else }}
+				{{ . }}
+			{{ end }}
+		{{ end }}`
+	return []helm.Node{
+		helm.NewNode(
+			regexp.MustCompile(`(^|\}\})\s+(\{\{|$)`).
+				ReplaceAllString(sanitizeNameHelper, "${1}${2}"),
+			helm.Comment(`
+				fissile.SanitizeName returns the given parameter, up to 63 characters long.
+				This should be called as {{ template "fissile.SanitizeName" "foo" }}
+				`)),
+	}
+}

--- a/kube/templates_test.go
+++ b/kube/templates_test.go
@@ -1,0 +1,41 @@
+package kube
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"code.cloudfoundry.org/fissile/helm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetHelmTemplateHelpers(t *testing.T) {
+	t.Run("fissile.SanitizeName", func(t *testing.T) {
+		for _, testcase := range []struct {
+			length   int
+			expected string
+		}{
+			{
+				length:   63,
+				expected: strings.Repeat("a", 63),
+			},
+			{
+				length:   64,
+				expected: strings.Repeat("a", 54) + "-ffe054fe",
+			},
+		} {
+			func(length int, expected string) {
+				t.Run(fmt.Sprintf("name of length %d", length), func(t *testing.T) {
+					t.Parallel()
+					name := strings.Repeat("a", length)
+					node := helm.NewNode(fmt.Sprintf(`{{ template "fissile.SanitizeName" %q }}`, name))
+					rendered, err := RoundtripNode(node, nil)
+					assert.True(t, len(rendered.(string)) < 64, "sanitized name is too long")
+					if assert.NoError(t, err) {
+						assert.Equal(t, expected, rendered.(string))
+					}
+				})
+			}(testcase.length, testcase.expected)
+		}
+	})
+}

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -39,7 +39,7 @@ func newSelector(role *model.InstanceGroup, settings ExportSettings) *helm.Mappi
 	return meta
 }
 
-// ConfigBuilder sets up generic a Kube resource structure with minimal metadata.
+// ConfigBuilder sets up a generic Kube resource structure with minimal metadata.
 type ConfigBuilder struct {
 	settings   *ExportSettings
 	apiVersion string
@@ -59,7 +59,7 @@ func (b *ConfigBuilder) setError(err error) {
 	if b.err == nil {
 		b.err = err
 	} else {
-		b.err = fmt.Errorf("%v: %v", b.err, err)
+		b.err = fmt.Errorf("%v, %v", b.err, err)
 	}
 }
 
@@ -96,6 +96,15 @@ func (b *ConfigBuilder) SetNameHelmExpression(name string) *ConfigBuilder {
 		b.setError(fmt.Errorf("name was set as a Helm expression before settings was set"))
 	} else if !b.settings.CreateHelmChart {
 		b.setError(fmt.Errorf("name is a Helm expression, but not creating a helm chart"))
+	}
+	if !strings.HasPrefix(name, "{{") {
+		b.setError(fmt.Errorf(`name "%s" does not start with "{{"`, name))
+	}
+	if !strings.HasSuffix(name, "}}") {
+		b.setError(fmt.Errorf(`name "%s" does not end with "}}"`, name))
+	}
+	if strings.ContainsRune(name, '\n') {
+		b.setError(fmt.Errorf(`name "%q" contains new line characters`, name))
 	}
 	b.name = name
 	return b

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -39,9 +39,84 @@ func newSelector(role *model.InstanceGroup, settings ExportSettings) *helm.Mappi
 	return meta
 }
 
-// newKubeConfig sets up generic a Kube config structure with minimal metadata
-func newKubeConfig(settings ExportSettings, apiVersion, kind, name string, modifiers ...helm.NodeModifier) *helm.Mapping {
-	labels := helm.NewMapping(RoleNameLabel, name) // "app.kubernetes.io/component"
+// ConfigBuilder sets up generic a Kube resource structure with minimal metadata.
+type ConfigBuilder struct {
+	settings   *ExportSettings
+	apiVersion string
+	kind       string
+	name       string
+	modifiers  []helm.NodeModifier
+
+	err error
+}
+
+// NewConfigBuilder constructs a new ConfigBuilder.
+func NewConfigBuilder() *ConfigBuilder {
+	return &ConfigBuilder{}
+}
+
+func (b *ConfigBuilder) setError(err error) {
+	if b.err == nil {
+		b.err = err
+	} else {
+		b.err = fmt.Errorf("%v: %v", b.err, err)
+	}
+}
+
+// SetSettings sets the export settings to be used by the builder.
+func (b *ConfigBuilder) SetSettings(settings *ExportSettings) *ConfigBuilder {
+	b.settings = settings
+	return b
+}
+
+// SetAPIVersion sets the kube API version of the resource to build.
+func (b *ConfigBuilder) SetAPIVersion(apiVersion string) *ConfigBuilder {
+	b.apiVersion = apiVersion
+	return b
+}
+
+// SetKind sets the kubernetes resource kind of the resource to build.
+func (b *ConfigBuilder) SetKind(kind string) *ConfigBuilder {
+	b.kind = kind
+	return b
+}
+
+// SetName sets the name of the resource to build.
+func (b *ConfigBuilder) SetName(name string) *ConfigBuilder {
+	if len(name) > 63 {
+		b.setError(fmt.Errorf("kube name exceeds 63 characters"))
+	}
+	b.name = name
+	return b
+}
+
+// SetNameHelmExpression sets the name of the resource to build as a Helm template expression.
+func (b *ConfigBuilder) SetNameHelmExpression(name string) *ConfigBuilder {
+	if b.settings == nil {
+		b.setError(fmt.Errorf("name was set as a Helm expression before settings was set"))
+	} else if !b.settings.CreateHelmChart {
+		b.setError(fmt.Errorf("name is a Helm expression, but not creating a helm chart"))
+	}
+	b.name = name
+	return b
+}
+
+// AddModifier adds a modifier to be used by the builder.
+func (b *ConfigBuilder) AddModifier(modifier helm.NodeModifier) *ConfigBuilder {
+	b.modifiers = append(b.modifiers, modifier)
+	return b
+}
+
+// Build the final kube resource.
+func (b *ConfigBuilder) Build() (*helm.Mapping, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+	if b.settings == nil {
+		return nil, fmt.Errorf("settings was not set")
+	}
+
+	labels := helm.NewMapping(RoleNameLabel, b.name) // "app.kubernetes.io/component"
 	istioAppLabel := map[string]bool{
 		"StatefulSet": true,
 		"Deployment":  true,
@@ -54,27 +129,27 @@ func newKubeConfig(settings ExportSettings, apiVersion, kind, name string, modif
 		"Pod":         true,
 	}
 
-	if settings.CreateHelmChart {
+	if b.settings.CreateHelmChart {
 		// XXX skiff-role-name is the legacy RoleNameLabel and will be removed in a future release
-		labels.Add("skiff-role-name", name)
+		labels.Add("skiff-role-name", b.name)
 		labels.Add("app.kubernetes.io/instance", `{{ .Release.Name | quote }}`)
 		labels.Add("app.kubernetes.io/managed-by", `{{ .Release.Service | quote }}`)
 		labels.Add("app.kubernetes.io/name", `{{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}`)
 		labels.Add("app.kubernetes.io/version", `{{ default .Chart.Version .Chart.AppVersion | quote }}`)
 		// labels.Add("app.kubernetes.io/part-of", `???`)
 		labels.Add("helm.sh/chart", `{{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}`)
-		if istioAppLabel[kind] {
-			labels.Add(AppNameLabel, name, helm.Block("if .Values.config.use_istio"))
+		if istioAppLabel[b.kind] {
+			labels.Add(AppNameLabel, b.name, helm.Block("if .Values.config.use_istio"))
 		}
-		if istioVersionLabel[kind] {
+		if istioVersionLabel[b.kind] {
 			labels.Add(AppVersionLabel, `{{ default .Chart.Version .Chart.AppVersion | quote }}`, helm.Block("if .Values.config.use_istio"))
 		}
 	}
 
-	config := newTypeMeta(apiVersion, kind, modifiers...)
-	config.Add("metadata", helm.NewMapping("name", name, "labels", labels))
+	config := newTypeMeta(b.apiVersion, b.kind, b.modifiers...)
+	config.Add("metadata", helm.NewMapping("name", b.name, "labels", labels))
 
-	return config
+	return config, nil
 }
 
 func makeVarName(name string) string {

--- a/kube/utils_test.go
+++ b/kube/utils_test.go
@@ -79,7 +79,15 @@ func TestNewKubeConfig(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	kubeConfig := newKubeConfig(ExportSettings{}, "theApiVersion", "thekind", "thename")
+	cb := NewConfigBuilder().
+		SetSettings(&ExportSettings{}).
+		SetAPIVersion("theApiVersion").
+		SetKind("thekind").
+		SetName("thename")
+	kubeConfig, err := cb.Build()
+	if !assert.NoError(err) {
+		return
+	}
 
 	actual, err := RoundtripKube(kubeConfig)
 	if !assert.NoError(err) {


### PR DESCRIPTION
Kubernetes doesn't like resource names longer than 63 characters.  Try to make it so all the names are shorter than that (by including part of the hash of the full thing).

Co-authored-by: Mark Yen <mark.yen@suse.com>