### PR TITLE
No `*-set` service for individual jobs

### DIFF
--- a/kube/service.go
+++ b/kube/service.go
@@ -25,17 +25,6 @@ func NewServiceList(role *model.InstanceGroup, clustering bool, settings ExportS
 	}
 
 	for _, job := range role.JobReferences {
-		if clustering {
-			// Create headless, private service
-			svc, err := newService(role, job, newServiceTypeHeadless, settings)
-			if err != nil {
-				return nil, err
-			}
-			if svc != nil {
-				items = append(items, svc)
-			}
-		}
-
 		// Create private service
 		svc, err := newService(role, job, newServiceTypePrivate, settings)
 		if err != nil {


### PR DESCRIPTION
Testing if this is a fix for some service name collisions.
This doesn't look like it's needed - since there's the umbrella headless service that exposes all ports from all jobs.

DON'T MERGE