### PR TITLE
Fix duplicate headless services 

### DIFF
--- a/kube/service.go
+++ b/kube/service.go
@@ -25,17 +25,6 @@ func NewServiceList(role *model.InstanceGroup, clustering bool, settings ExportS
 	}
 
 	for _, job := range role.JobReferences {
-		if clustering {
-			// Create headless, private service
-			svc, err := newService(role, job, newServiceTypeHeadless, settings)
-			if err != nil {
-				return nil, err
-			}
-			if svc != nil {
-				items = append(items, svc)
-			}
-		}
-
 		// Create private service
 		svc, err := newService(role, job, newServiceTypePrivate, settings)
 		if err != nil {

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -776,42 +776,6 @@ func TestActivePassiveService(t *testing.T) {
 										testhelpers.IsYAMLEqualString(assert.New(t), expected, actual)
 									}
 								}
-								if assert.NotNil(t, headlessService, "headless service not found") {
-									actual, err := roundTrip(headlessService)
-									if assert.NoError(t, err) {
-										expected := expectedYAML(exportSettings, `---
-											apiVersion: v1
-											kind: Service
-											metadata:
-												name: myrole-tor-set
-												labels:
-													app.kubernetes.io/component: myrole-tor-set
-													app.kubernetes.io/instance: MyRelease
-													app.kubernetes.io/managed-by: Tiller
-													app.kubernetes.io/name: MyChart
-													app.kubernetes.io/version: 1.22.333.4444
-													helm.sh/chart: MyChart-42.1_foo
-													skiff-role-name: "myrole-tor-set"
-											spec:
-												clusterIP: None
-												ports:
-												-
-													name: http
-													port: 80
-													protocol: TCP
-													targetPort: 0
-												-
-													name: https
-													port: 443
-													protocol: TCP
-													targetPort: 0
-												selector:
-													app.kubernetes.io/component: myrole
-													skiff-role-active: "true"
-										`)
-										testhelpers.IsYAMLEqualString(assert.New(t), expected, actual)
-									}
-								}
 							} else {
 								assert.Nil(t, headlessService, "Headless service should not be created when not clustering")
 							}


### PR DESCRIPTION
Current setup will generate two headless svc´s, these are `<role>-<job>-set` and `<role>-set`.
When using the `service_name` key in an specific job, in order to rename the svc´s, having both headless svc´s will lead to duplicate svc´s .

A more precise example is the `nats` role. Without using the `service_name` key in an `instance_group` job, the headless svcs will be:
```
nats-nats-set
nats-set
```
When using the  `service_name` key, to enforce the name of `uaa`. the headless svcs will be:
```
nats-set
nats-set
```
which will lead to the svc´s duplication.

After speaking with @viovanov about this, he mentioned that the the `<role>-<job>-set` svc, is not widely used, and only a reference to it is found in:
 - https://github.com/SUSE/scf/blob/develop/container-host-files/etc/scf/config/role-manifest.yml#L2241

Therefore this PR to remove the `<role>-<job>-set` svc .