### PR TITLE
Optional repository prefix

### DIFF
--- a/builder/packages_image.go
+++ b/builder/packages_image.go
@@ -250,7 +250,7 @@ func (p *PackagesImageBuilder) GetImageName(roleManifest *model.RoleManifest, in
 		hasher.Write([]byte(strings.Join([]string{"", pkg.Fingerprint, pkg.Name, pkg.SHA1}, "\000")))
 	}
 
-	imageName := util.SanitizeDockerName(fmt.Sprintf("%s-role-packages", p.RepositoryPrefix))
+	imageName := util.SanitizeDockerName(util.PrefixString("role-packages", p.RepositoryPrefix, "-"))
 	imageTag := util.SanitizeDockerName(hex.EncodeToString(hasher.Sum(nil)))
 	result := fmt.Sprintf("%s:%s", imageName, imageTag)
 

--- a/builder/release_image.go
+++ b/builder/release_image.go
@@ -191,7 +191,7 @@ func (j releaseBuildJob) imageName() (string, error) {
 	if j.builder.DockerOrganization != "" {
 		imageName += util.SanitizeDockerName(j.builder.DockerOrganization) + "/"
 	}
-	imageName += util.SanitizeDockerName(fmt.Sprintf("%s-%s", j.builder.RepositoryPrefix, j.release.Name))
+	imageName += util.SanitizeDockerName(util.PrefixString(j.release.Name, j.builder.RepositoryPrefix, "-"))
 
 	fissileVersion := strings.Replace(j.builder.FissileVersion, "fissile-", "", -1)
 	fissileVersion = strings.Replace(fissileVersion, "+", "_", -1)

--- a/builder/role_image.go
+++ b/builder/role_image.go
@@ -493,7 +493,7 @@ func GetRoleDevImageName(registry, organization, repositoryPrefix string, instan
 		imageName += util.SanitizeDockerName(organization) + "/"
 	}
 
-	imageName += util.SanitizeDockerName(fmt.Sprintf("%s-%s", repositoryPrefix, instanceGroup.Name))
+	imageName += util.SanitizeDockerName(util.PrefixString(instanceGroup.Name, repositoryPrefix, "-"))
 
 	return fmt.Sprintf("%s:%s", imageName, util.SanitizeDockerName(version))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,7 @@ var RootCmd = &cobra.Command{
 	Long: `
 Fissile converts existing BOSH final or dev releases into docker images.
 
-It does this using just the releases, without a BOSH deployment, CPIs, or a BOSH 
+It does this using just the releases, without a BOSH deployment, CPIs, or a BOSH
 agent.
 `,
 	SilenceErrors: true,
@@ -112,7 +112,7 @@ func init() {
 	RootCmd.PersistentFlags().StringP(
 		"repository",
 		"p",
-		"fissile",
+		"",
 		"Repository name prefix used to create image names.",
 	)
 

--- a/util/string_utils.go
+++ b/util/string_utils.go
@@ -1,10 +1,11 @@
 package util
 
 import (
+	"fmt"
 	"strings"
 )
 
-// StringInSlice checks if the given string is in the given string slice, ignoring case differences
+// StringInSlice checks if the given string is in the given string slice, ignoring case differences.
 func StringInSlice(needle string, haystack []string) bool {
 	for _, element := range haystack {
 		if strings.EqualFold(needle, element) {
@@ -12,4 +13,12 @@ func StringInSlice(needle string, haystack []string) bool {
 		}
 	}
 	return false
+}
+
+// PrefixString prefixes the provided 'str' with 'prefix' using 'separator' between them.
+func PrefixString(str, prefix, separator string) string {
+	if prefix != "" {
+		return fmt.Sprintf("%s%s%s", prefix, separator, str)
+	}
+	return str
 }

--- a/util/string_utils_test.go
+++ b/util/string_utils_test.go
@@ -1,0 +1,82 @@
+package util_test
+
+import (
+	"testing"
+
+	"code.cloudfoundry.org/fissile/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringInSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		needle   string
+		haystack []string
+		expected bool
+	}{
+		{
+			name:     "should not match",
+			needle:   "one",
+			haystack: []string{"two", "three", "four"},
+			expected: false,
+		},
+		{
+			name:     "should match exactly",
+			needle:   "two",
+			haystack: []string{"one", "two", "three", "four"},
+			expected: true,
+		},
+		{
+			name:     "should match case-insensitive",
+			needle:   "foUr",
+			haystack: []string{"ONE", "TWO", "THREE", "FOUR"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := util.StringInSlice(tt.needle, tt.haystack)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestPrefixString(t *testing.T) {
+	tests := []struct {
+		name      string
+		str       string
+		prefix    string
+		separator string
+		expected  string
+	}{
+		{
+			name:      "empty prefix",
+			str:       "something",
+			prefix:    "",
+			separator: ".",
+			expected:  "something",
+		},
+		{
+			name:      "empty separator",
+			str:       "something",
+			prefix:    "do",
+			separator: "",
+			expected:  "dosomething",
+		},
+		{
+			name:      "all set",
+			str:       "something",
+			prefix:    "do",
+			separator: "-",
+			expected:  "do-something",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := util.PrefixString(tt.str, tt.prefix, tt.separator)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds the possibility of `--repository` being empty.
Also, changes the `--repository` default from `fissile` to empty string.

[#164446604](https://www.pivotaltracker.com/n/projects/2192232/stories/164446604)

## Test plan

- Create the nats image without setting the repository, should get an image `something/nats`:

```
fissile build release-images \
  --stemcell="splatform/fissile-stemcell-opensuse" \
  --name="nats" \
  --version=26 \
  --sha1=2f2c27acdfff81f3519968921686522518ab5783 \
  --url="https://bosh.io/d/github.com/cloudfoundry/nats-release?v=26" \
  --docker-organization="something" 
```

- Create the nats image setting the repository, should get an image `something/myprefix-nats`:

```
fissile build release-images \
  --stemcell="splatform/fissile-stemcell-opensuse" \
  --name="nats" \
  --version=26 \
  --sha1=2f2c27acdfff81f3519968921686522518ab5783 \
  --url="https://bosh.io/d/github.com/cloudfoundry/nats-release?v=26" \
  --docker-organization="something" \
  --repository="myprefix"
```