### PR TITLE
Replace combination of build-time smylinks and runtime moves with build time moves.

### DIFF
--- a/builder/role_image.go
+++ b/builder/role_image.go
@@ -88,29 +88,6 @@ func (r *RoleImageBuilder) NewDockerPopulator(instanceGroup *model.InstanceGroup
 			}
 		}
 
-		// Symlink compiled packages
-		packageSet := map[string]string{}
-		for _, jobReference := range instanceGroup.JobReferences {
-			for _, pkg := range jobReference.Packages {
-				if _, ok := packageSet[pkg.Name]; !ok {
-					err := util.WriteToTarStream(tarWriter, nil, tar.Header{
-						Name:     filepath.Join("root/var/vcap/packages", pkg.Name),
-						Typeflag: tar.TypeSymlink,
-						Linkname: filepath.Join("..", "packages-src", pkg.Fingerprint),
-					})
-					if err != nil {
-						return fmt.Errorf("failed to write package symlink for %s: %s", pkg.Name, err)
-					}
-					packageSet[pkg.Name] = pkg.Fingerprint
-				} else {
-					if pkg.Fingerprint != packageSet[pkg.Name] {
-						r.UI.Printf("WARNING: duplicate package %s. Using package with fingerprint %s.\n",
-							color.CyanString(pkg.Name), color.RedString(packageSet[pkg.Name]))
-					}
-				}
-			}
-		}
-
 		// Copy jobs templates, spec configs and monit
 		for _, jobReference := range instanceGroup.JobReferences {
 			err := addJobTemplates(jobReference.Job, "root/var/vcap/jobs-src", tarWriter)
@@ -300,13 +277,41 @@ func (r *RoleImageBuilder) generateDockerfile(instanceGroup *model.InstanceGroup
 		return err
 	}
 
-	dockerfileTemplate := template.New("Dockerfile-role")
+	// In a role move the packages from /var/vcap/packages-src to
+	// /var/vcap/packages.  This replaces the original form of
+	// symlinking them into place.  The change is necessary
+	// because the symlinks will not resolve inside bpm containers.
+
+	packageSet := map[string]string{}
+	moves := []string{}
+
+	for _, jobReference := range instanceGroup.JobReferences {
+		for _, pkg := range jobReference.Packages {
+			if _, ok := packageSet[pkg.Name]; !ok {
+				// Generate a docker move command
+				destination := filepath.Join("root/var/vcap/packages", pkg.Name)
+				origin := filepath.Join("root/var/vcap/packages-src", pkg.Fingerprint)
+				move := fmt.Sprintf("RUN mv %s %s", origin, destination)
+				moves = append(moves, move)
+
+				packageSet[pkg.Name] = pkg.Fingerprint
+			} else {
+				if pkg.Fingerprint != packageSet[pkg.Name] {
+					r.UI.Printf("WARNING: duplicate package %s. Using package with fingerprint %s.\n",
+						color.CyanString(pkg.Name), color.RedString(packageSet[pkg.Name]))
+				}
+			}
+		}
+	}
 
 	context := map[string]interface{}{
 		"base_image":     r.BaseImageName,
 		"instance_group": instanceGroup,
 		"licenses":       instanceGroup.JobReferences[0].Release.License.Files,
+		"moves":          moves,
 	}
+
+	dockerfileTemplate := template.New("Dockerfile-role")
 
 	dockerfileTemplate, err = dockerfileTemplate.Parse(string(asset))
 	if err != nil {

--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -214,8 +214,6 @@ func TestGenerateRoleImageDockerfileDir(t *testing.T) {
 	roleImageBuilder := newRoleImageBuilder(roleManifestPath, lightOpinionsPath, darkOpinionsPath)
 	roleImageBuilder.BaseImageName = releasePathConfigSpec
 
-	torPkg := getPackage(roleManifest.InstanceGroups, "myrole", "tor", "tor")
-
 	const TypeMissing byte = tar.TypeCont // flag to indicate an expected missing file
 	expected := map[string]struct {
 		desc     string
@@ -234,7 +232,6 @@ func TestGenerateRoleImageDockerfileDir(t *testing.T) {
 		"root/var/vcap/jobs-src/tor/templates/bin/monit_debugger": {desc: "job template file"},
 		"root/var/vcap/jobs-src/tor/config_spec.json":             {desc: "tor config spec", keep: true, mode: 0644},
 		"root/var/vcap/jobs-src/new_hostname/config_spec.json":    {desc: "new_hostname config spec", keep: true},
-		"root/var/vcap/packages/tor":                              {desc: "package symlink", typeflag: tar.TypeSymlink, keep: true},
 	}
 	actual := make(map[string][]byte)
 
@@ -295,11 +292,6 @@ func TestGenerateRoleImageDockerfileDir(t *testing.T) {
 
 	for name, info := range expected {
 		assert.Equal(TypeMissing, info.typeflag, "File %s was not found", name)
-	}
-
-	if assert.Contains(actual, "root/var/vcap/packages/tor", "tor package missing") {
-		expectedTarget := filepath.Join("..", "packages-src", torPkg.Fingerprint)
-		assert.Equal(string(actual["root/var/vcap/packages/tor"]), expectedTarget)
 	}
 
 	// And verify the config specs are as expected

--- a/scripts/dockerfiles/Dockerfile-role
+++ b/scripts/dockerfiles/Dockerfile-role
@@ -7,5 +7,8 @@ MAINTAINER cloudfoundry@suse.example
 LABEL "instance_group"="{{ .instance_group.Name }}"
 
 ADD root /
+{{ range .moves }}
+{{ . }}
+{{ end }}
 
 ENTRYPOINT ["/usr/bin/dumb-init", "/opt/fissile/run.sh"]

--- a/scripts/dockerfiles/Dockerfile-role
+++ b/scripts/dockerfiles/Dockerfile-role
@@ -7,8 +7,8 @@ MAINTAINER cloudfoundry@suse.example
 LABEL "instance_group"="{{ .instance_group.Name }}"
 
 ADD root /
-{{ range .moves }}
-{{ . }}
+{{ range .runCommands }}
+RUN {{ . }}
 {{ end }}
 
 ENTRYPOINT ["/usr/bin/dumb-init", "/opt/fissile/run.sh"]

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -108,18 +108,6 @@ ln -s /var/vcap/jobs /var/vcap/data/jobs
 ln -s /var/vcap/packages /var/vcap/data/packages
 ln -s /var/vcap/sys /var/vcap/data/sys
 
-# Move packages from /var/vcap/packages-src to /var/vcap/packages
-# This is necessary because the ../packages-src symlink does not resolve inside bpm containers
-if test -d /var/vcap/packages/bpm ; then
-    # In a BPM world, /var/vcap/packages isn't mapped into the chroot
-    for pkg in /var/vcap/packages/*; do
-        target=$(readlink -f "${pkg}")
-        rm "${pkg}"
-        mv "${target}" "${pkg}"
-        chown -R vcap:vcap "${pkg}" # Work around strange permission issues
-    done
-fi
-
 # Run custom environment scripts (that are sourced)
 {{ range $script := .instance_group.EnvironScripts }}
     source {{ script_path $script }}


### PR DESCRIPTION
Ref https://trello.com/c/H2AXtiHz/974-packages-mv-should-happen-at-build-time

Controlling SCF PR https://github.com/SUSE/scf/pull/2191

Drop symlinks for the role tarball.
Use `mv` in the Dockerfile instead.
Removed transform of symlinks into `mv` from the runtime role startup.

:white_check_mark: check unit tests
:white_check_mark: Get check build
:white_check_mark: Trial with SCF (and actual packages to move)
