### PR TITLE
Allow roles with sizing.min=0 to be on by default

### DIFF
--- a/kube/values.go
+++ b/kube/values.go
@@ -104,7 +104,13 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 					instanceGroup.Run.Scaling.HA)
 			}
 		}
-		entry.Add("count", instanceGroup.Run.Scaling.Min, helm.Comment(comment))
+
+		count := instanceGroup.Run.Scaling.Default
+		if count == 0 {
+			count = instanceGroup.Run.Scaling.Min
+		}
+
+		entry.Add("count", count, helm.Comment(comment))
 		if settings.UseMemoryLimits {
 			var request helm.Node
 			if instanceGroup.Run.Memory.Request == nil {

--- a/kube/values_test.go
+++ b/kube/values_test.go
@@ -77,6 +77,65 @@ func TestMakeValues(t *testing.T) {
 		assert.Contains(t, sizing.Comment(), "underscore")
 	})
 
+	t.Run("Sizing Min", func(t *testing.T) {
+		t.Parallel()
+		settings := ExportSettings{
+			OutputDir: outDir,
+			RoleManifest: &model.RoleManifest{
+				InstanceGroups: model.InstanceGroups{
+					&model.InstanceGroup{
+						Name: "arole",
+						Run: &model.RoleRun{
+							Scaling: &model.RoleRunScaling{
+								Min: 7,
+								Max: 9,
+							},
+						},
+					},
+				},
+				Configuration: &model.Configuration{},
+			},
+		}
+
+		node, err := MakeValues(settings)
+		assert.NoError(t, err)
+		require.NotNil(t, node)
+
+		sizing := node.Get("sizing")
+		require.NotNil(t, sizing)
+		assert.Contains(t, sizing.String(), "count: 7")
+	})
+
+	t.Run("Sizing Min with Default", func(t *testing.T) {
+		t.Parallel()
+		settings := ExportSettings{
+			OutputDir: outDir,
+			RoleManifest: &model.RoleManifest{
+				InstanceGroups: model.InstanceGroups{
+					&model.InstanceGroup{
+						Name: "arole",
+						Run: &model.RoleRun{
+							Scaling: &model.RoleRunScaling{
+								Min:     7,
+								Max:     9,
+								Default: 8,
+							},
+						},
+					},
+				},
+				Configuration: &model.Configuration{},
+			},
+		}
+
+		node, err := MakeValues(settings)
+		assert.NoError(t, err)
+		require.NotNil(t, node)
+
+		sizing := node.Get("sizing")
+		require.NotNil(t, sizing)
+		assert.Contains(t, sizing.String(), "count: 8")
+	})
+
 	t.Run("Check Default Registry", func(t *testing.T) {
 		t.Parallel()
 		settings := ExportSettings{

--- a/model/role_run.go
+++ b/model/role_run.go
@@ -49,6 +49,7 @@ type RoleRunCPU struct {
 type RoleRunScaling struct {
 	Min       int  `yaml:"min"`
 	Max       int  `yaml:"max"`
+	Default   int  `yaml:"default"`
 	HA        int  `yaml:"ha,omitempty"`
 	MustBeOdd bool `yaml:"must_be_odd,omitempty"`
 }
@@ -151,6 +152,9 @@ func (r *RoleRun) setScaling(jobReferences JobReferences) {
 	})
 	r.Scaling.Min = maxInteger(jobReferences, func(j JobReference) int {
 		return j.ContainerProperties.BoshContainerization.Run.Scaling.Min
+	})
+	r.Scaling.Default = maxInteger(jobReferences, func(j JobReference) int {
+		return j.ContainerProperties.BoshContainerization.Run.Scaling.Default
 	})
 	r.Scaling.MustBeOdd = anyMustBeOdd(jobReferences)
 


### PR DESCRIPTION
We need the capability to turn off roles that are on by default.
e.g. diego roles are on by default (default count of 1) but can be turned off (count 0) when eirini is enabled