### PR TITLE
Rename /var/vcap/packages-src to /var/vcap/packages/.src

### DIFF
--- a/builder/packages_image_test.go
+++ b/builder/packages_image_test.go
@@ -75,7 +75,7 @@ func TestGenerateDockerfile(t *testing.T) {
 	lines := getDockerfileLines(dockerfile.String())
 	assert.Equal([]string{
 		"FROM scratch:latest",
-		"ADD packages-src /var/vcap/packages-src/",
+		"ADD packages-src /var/vcap/packages/.src/",
 		"LABEL version.generator.fissile=3.14.15",
 		`LABEL "publisher"="SUSE Linux Products GmbH"`,
 		`LABEL "version.cap"="1.2.3"`,
@@ -142,7 +142,7 @@ func TestNewDockerPopulator(t *testing.T) {
 			testers := []func(){
 				func() { assert.Equal(fmt.Sprintf("FROM %s", baseImage.ID), line, "line 1 should start with FROM") },
 				func() {
-					assert.Equal("ADD packages-src /var/vcap/packages-src/", line, "line 3 mismatch (ADD, package src location)")
+					assert.Equal("ADD packages-src /var/vcap/packages/.src/", line, "line 3 mismatch (ADD, package src location)")
 				},
 				func() {
 					assert.Equal("LABEL version.generator.fissile=3.14.15", line, "line 4 mismatch (LABEL, generator version)")

--- a/builder/role_image.go
+++ b/builder/role_image.go
@@ -96,7 +96,7 @@ func (r *RoleImageBuilder) NewDockerPopulator(instanceGroup *model.InstanceGroup
 					err := util.WriteToTarStream(tarWriter, nil, tar.Header{
 						Name:     filepath.Join("root/var/vcap/packages", pkg.Name),
 						Typeflag: tar.TypeSymlink,
-						Linkname: filepath.Join("..", "packages-src", pkg.Fingerprint),
+						Linkname: filepath.Join("..", "packages", ".src", pkg.Fingerprint),
 					})
 					if err != nil {
 						return fmt.Errorf("failed to write package symlink for %s: %s", pkg.Name, err)

--- a/builder/role_image.go
+++ b/builder/role_image.go
@@ -88,6 +88,29 @@ func (r *RoleImageBuilder) NewDockerPopulator(instanceGroup *model.InstanceGroup
 			}
 		}
 
+		// Symlink compiled packages
+		packageSet := map[string]string{}
+		for _, jobReference := range instanceGroup.JobReferences {
+			for _, pkg := range jobReference.Packages {
+				if _, ok := packageSet[pkg.Name]; !ok {
+					err := util.WriteToTarStream(tarWriter, nil, tar.Header{
+						Name:     filepath.Join("root/var/vcap/packages", pkg.Name),
+						Typeflag: tar.TypeSymlink,
+						Linkname: filepath.Join("..", "packages-src", pkg.Fingerprint),
+					})
+					if err != nil {
+						return fmt.Errorf("failed to write package symlink for %s: %s", pkg.Name, err)
+					}
+					packageSet[pkg.Name] = pkg.Fingerprint
+				} else {
+					if pkg.Fingerprint != packageSet[pkg.Name] {
+						r.UI.Printf("WARNING: duplicate package %s. Using package with fingerprint %s.\n",
+							color.CyanString(pkg.Name), color.RedString(packageSet[pkg.Name]))
+					}
+				}
+			}
+		}
+
 		// Copy jobs templates, spec configs and monit
 		for _, jobReference := range instanceGroup.JobReferences {
 			err := addJobTemplates(jobReference.Job, "root/var/vcap/jobs-src", tarWriter)
@@ -277,47 +300,13 @@ func (r *RoleImageBuilder) generateDockerfile(instanceGroup *model.InstanceGroup
 		return err
 	}
 
-	// In a role move the packages from /var/vcap/packages-src to
-	// /var/vcap/packages.  This replaces the original form of
-	// symlinking them into place.  The change is necessary
-	// because the symlinks will not resolve inside bpm containers.
-
-	packageSet := map[string]string{}
-	runCommands := []string{}
-	first := true
-
-	for _, jobReference := range instanceGroup.JobReferences {
-		for _, pkg := range jobReference.Packages {
-			if _, ok := packageSet[pkg.Name]; !ok {
-				// Make package destination once
-				if first {
-					runCommands = append(runCommands, "mkdir -p /var/vcap/packages")
-					first = false
-				}
-				// Move the package into place
-				destination := filepath.Join("/var/vcap/packages", pkg.Name)
-				origin := filepath.Join("/var/vcap/packages-src", pkg.Fingerprint)
-				move := fmt.Sprintf("mv %s %s", origin, destination)
-				runCommands = append(runCommands, move)
-
-				packageSet[pkg.Name] = pkg.Fingerprint
-			} else {
-				if pkg.Fingerprint != packageSet[pkg.Name] {
-					r.UI.Printf("WARNING: duplicate package %s. Using package with fingerprint %s.\n",
-						color.CyanString(pkg.Name), color.RedString(packageSet[pkg.Name]))
-				}
-			}
-		}
-	}
+	dockerfileTemplate := template.New("Dockerfile-role")
 
 	context := map[string]interface{}{
 		"base_image":     r.BaseImageName,
 		"instance_group": instanceGroup,
 		"licenses":       instanceGroup.JobReferences[0].Release.License.Files,
-		"runCommands":    runCommands,
 	}
-
-	dockerfileTemplate := template.New("Dockerfile-role")
 
 	dockerfileTemplate, err = dockerfileTemplate.Parse(string(asset))
 	if err != nil {

--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -298,7 +298,7 @@ func TestGenerateRoleImageDockerfileDir(t *testing.T) {
 	}
 
 	if assert.Contains(actual, "root/var/vcap/packages/tor", "tor package missing") {
-		expectedTarget := filepath.Join("..", "packages-src", torPkg.Fingerprint)
+		expectedTarget := filepath.Join("..", "packages", ".src", torPkg.Fingerprint)
 		assert.Equal(string(actual["root/var/vcap/packages/tor"]), expectedTarget)
 	}
 

--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -214,6 +214,8 @@ func TestGenerateRoleImageDockerfileDir(t *testing.T) {
 	roleImageBuilder := newRoleImageBuilder(roleManifestPath, lightOpinionsPath, darkOpinionsPath)
 	roleImageBuilder.BaseImageName = releasePathConfigSpec
 
+	torPkg := getPackage(roleManifest.InstanceGroups, "myrole", "tor", "tor")
+
 	const TypeMissing byte = tar.TypeCont // flag to indicate an expected missing file
 	expected := map[string]struct {
 		desc     string
@@ -232,6 +234,7 @@ func TestGenerateRoleImageDockerfileDir(t *testing.T) {
 		"root/var/vcap/jobs-src/tor/templates/bin/monit_debugger": {desc: "job template file"},
 		"root/var/vcap/jobs-src/tor/config_spec.json":             {desc: "tor config spec", keep: true, mode: 0644},
 		"root/var/vcap/jobs-src/new_hostname/config_spec.json":    {desc: "new_hostname config spec", keep: true},
+		"root/var/vcap/packages/tor":                              {desc: "package symlink", typeflag: tar.TypeSymlink, keep: true},
 	}
 	actual := make(map[string][]byte)
 
@@ -292,6 +295,11 @@ func TestGenerateRoleImageDockerfileDir(t *testing.T) {
 
 	for name, info := range expected {
 		assert.Equal(TypeMissing, info.typeflag, "File %s was not found", name)
+	}
+
+	if assert.Contains(actual, "root/var/vcap/packages/tor", "tor package missing") {
+		expectedTarget := filepath.Join("..", "packages-src", torPkg.Fingerprint)
+		assert.Equal(string(actual["root/var/vcap/packages/tor"]), expectedTarget)
 	}
 
 	// And verify the config specs are as expected

--- a/scripts/dockerfiles/Dockerfile-packages
+++ b/scripts/dockerfiles/Dockerfile-packages
@@ -1,6 +1,6 @@
 FROM {{ index . "base_image" }}
 
-ADD packages-src /var/vcap/packages-src/
+ADD packages-src /var/vcap/packages/.src/
 
 LABEL {{ index . "fissile_version" }}
 {{ range $label, $value := .labels }}

--- a/scripts/dockerfiles/Dockerfile-role
+++ b/scripts/dockerfiles/Dockerfile-role
@@ -7,8 +7,5 @@ MAINTAINER cloudfoundry@suse.example
 LABEL "instance_group"="{{ .instance_group.Name }}"
 
 ADD root /
-{{ range .runCommands }}
-RUN {{ . }}
-{{ end }}
 
 ENTRYPOINT ["/usr/bin/dumb-init", "/opt/fissile/run.sh"]

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -108,18 +108,6 @@ ln -s /var/vcap/jobs /var/vcap/data/jobs
 ln -s /var/vcap/packages /var/vcap/data/packages
 ln -s /var/vcap/sys /var/vcap/data/sys
 
-# Move packages from /var/vcap/packages-src to /var/vcap/packages
-# This is necessary because the ../packages-src symlink does not resolve inside bpm containers
-if test -d /var/vcap/packages/bpm ; then
-    # In a BPM world, /var/vcap/packages isn't mapped into the chroot
-    for pkg in /var/vcap/packages/*; do
-        target=$(readlink -f "${pkg}")
-        rm "${pkg}"
-        mv "${target}" "${pkg}"
-        chown -R vcap:vcap "${pkg}" # Work around strange permission issues
-    done
-fi
-
 # Run custom environment scripts (that are sourced)
 {{ range $script := .instance_group.EnvironScripts }}
     source {{ script_path $script }}

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -108,6 +108,18 @@ ln -s /var/vcap/jobs /var/vcap/data/jobs
 ln -s /var/vcap/packages /var/vcap/data/packages
 ln -s /var/vcap/sys /var/vcap/data/sys
 
+# Move packages from /var/vcap/packages-src to /var/vcap/packages
+# This is necessary because the ../packages-src symlink does not resolve inside bpm containers
+if test -d /var/vcap/packages/bpm ; then
+    # In a BPM world, /var/vcap/packages isn't mapped into the chroot
+    for pkg in /var/vcap/packages/*; do
+        target=$(readlink -f "${pkg}")
+        rm "${pkg}"
+        mv "${target}" "${pkg}"
+        chown -R vcap:vcap "${pkg}" # Work around strange permission issues
+    done
+fi
+
 # Run custom environment scripts (that are sourced)
 {{ range $script := .instance_group.EnvironScripts }}
     source {{ script_path $script }}


### PR DESCRIPTION
Moving file is too slow and takes additional space in the image because it happens on a different layer.

By putting the `packages-src` directory inside `packages` it will automatically be mapped under BPM with no additional overhead.