### PR TITLE
Replaced pre-start scripts running logic using Go templating

### DIFF
--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -155,26 +155,12 @@ echo bash {{ script_path $script }}
 bash {{ script_path $script }}
 {{ end }}
 
-# Run all the scripts called pre-start, but ensure consul_agent/bin/pre-start is run before others.
-# None of the other pre-start scripts appear to have any dependencies on one another.
-function sorted-pre-start-paths() {
-  declare -a fnames
-  idx=0
-  if [ -x /var/vcap/jobs/consul_agent/bin/pre-start ] ; then
-    fnames[$idx]=/var/vcap/jobs/consul_agent/bin/pre-start
-    idx=$((idx + 1))
-  fi
-  for fname in $(find /var/vcap/jobs/*/bin -name pre-start | grep -v '/consul_agent/bin/pre-start$') ; do
-    fnames[$idx]=$fname
-    idx=$((idx + 1))
-  done
-  echo ${fnames[*]}
-}
-
-for fname in $(sorted-pre-start-paths) ; do
-  echo bash $fname
-  bash $fname
-done
+# Run pre-start scripts for each job.
+{{ range $job := .instance_group.JobReferences }}
+if [ -x /var/vcap/jobs/{{ $job.Name }}/bin/pre-start ] ; then
+  /var/vcap/jobs/{{ $job.Name }}/bin/pre-start
+fi
+{{ end }}
 
 # Run
 {{ if eq .instance_group.Type "bosh-task" -}}


### PR DESCRIPTION
## Description

Replaced the `find` approach with a Go templating approach. It executes the pre-start scripts in the order that was passed to the jobs field in the role manifest.

## Test plan

Make sure that the order passed to the jobs is respected when rendering `run.sh`.