### PR TITLE
Invoke pre-start scripts via explicit `bash`

### DIFF
--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -180,7 +180,8 @@ bash {{ script_path $script }}
 # Run pre-start scripts for each job.
 {{ range $job := .instance_group.JobReferences }}
 if [ -x /var/vcap/jobs/{{ $job.Name }}/bin/pre-start ] ; then
-  /var/vcap/jobs/{{ $job.Name }}/bin/pre-start
+  echo bash /var/vcap/jobs/{{ $job.Name }}/bin/pre-start
+  bash /var/vcap/jobs/{{ $job.Name }}/bin/pre-start
 fi
 {{ end }}
 


### PR DESCRIPTION
Ref https://trello.com/c/Ljs7a8lx/986-2-make-sure-authorize-internal-ca-pre-start-script-always-runs-first

PS to https://github.com/cloudfoundry-incubator/fissile/pull/485
Invoke the scripts with an explicit `bash`, like the old code did.

It looks as if at least one pre-start script has active options when called directly.

This PR is for testing if that is indeed the case.
The "proper" change would be to fix the pre-start script, given that it is the only one (so far).
This change here is a bit easier to create

:construction: :warning: :construction: 
__Do not merge__

