### PR TITLE
Fix colocated container volume count validation

### DIFF
--- a/model/resolver/resolver_test.go
+++ b/model/resolver/resolver_test.go
@@ -1064,6 +1064,28 @@ func TestLoadRoleManifestColocatedContainersValidationOfSharedVolumes(t *testing
 		"instance_group[main-role]: Required value: container must use shared volumes of the main instance group: vcap-store")
 }
 
+func TestLoadRoleManifestColocatedContainersValidationOfMultipleColocatedContainersWithDifferentMounts(t *testing.T) {
+	assert := assert.New(t)
+
+	workDir, err := os.Getwd()
+	assert.NoError(err)
+
+	torReleasePath := filepath.Join(workDir, "../../test-assets/tor-boshrelease")
+	ntpReleasePath := filepath.Join(workDir, "../../test-assets/ntp-release")
+	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/colocated-containers-with-different-volume-shares.yml")
+	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, LoadRoleManifestOptions{
+		ReleaseOptions: ReleaseOptions{
+			ReleasePaths:     []string{torReleasePath, ntpReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
+		ValidationOptions: RoleManifestValidationOptions{
+			AllowMissingScripts: true,
+		}})
+
+	assert.NotNil(roleManifest)
+	assert.Nil(err)
+}
+
 func TestLoadRoleManifestWithReleaseReferences(t *testing.T) {
 	workDir, err := os.Getwd()
 	assert.NoError(t, err)

--- a/test-assets/role-manifests/model/colocated-containers-with-different-volume-shares.yml
+++ b/test-assets/role-manifests/model/colocated-containers-with-different-volume-shares.yml
@@ -1,0 +1,44 @@
+---
+instance_groups:
+- name: main-role
+  scripts: [scripts/myrole.sh]
+  jobs:
+  - name: new_hostname
+    release: tor
+  - name: tor
+    release: tor
+    properties:
+      bosh_containerization:
+        colocated_containers:
+        - to-be-colocated-1
+        - to-be-colocated-2
+        run:
+          memory: 1
+          volumes:
+          - path: /shared/data
+            type: emptyDir
+            tag: shared-data
+
+- name: to-be-colocated-1
+  type: colocated-container
+  jobs:
+  - name: tor
+    release: tor
+    properties:
+      bosh_containerization:
+        run:
+          memory: 1
+          volumes:
+          - path: /shared/data
+            type: emptyDir
+            tag: shared-data
+
+- name: to-be-colocated-2
+  type: colocated-container
+  jobs:
+  - name: ntpd
+    release: ntp
+    properties:
+      bosh_containerization:
+        run:
+          memory: 1


### PR DESCRIPTION
Fix the colocated container volume validation that checks for unsed volumes
defined in the main instance group, which are not used by any colocated
container instance group. Do not compare the number of volumes, but check
that each volume definition of the main instance group is at least used
once by one of the colocated containers. The previous logic created false
validation errors in case multiple colocated containers were defined, but
not all of them used a shared volume.

This should fix #488.