### PR TITLE
Add feature flag details to values.yaml comments

### DIFF
--- a/model/instance_groups.go
+++ b/model/instance_groups.go
@@ -156,7 +156,7 @@ func (g *InstanceGroup) GetLongDescription() string {
 		}
 	}
 	if len(noDesc) > 0 {
-		desc += fmt.Sprintf("\n\n%s%s", also, strings.Join(noDesc, ", "))
+		desc += fmt.Sprintf("\n\n%s%s", also, util.WordList(noDesc, "and"))
 	}
 	return desc
 }

--- a/util/string_utils.go
+++ b/util/string_utils.go
@@ -22,3 +22,23 @@ func PrefixString(str, prefix, separator string) string {
 	}
 	return str
 }
+
+// WordList returns a string of all words in the 'words' slice. For 2 or more words the
+// last word is prefixed by `conjunction`, and if there are at least 3 words, then they
+// are separated by the oxford comma.
+//
+// WordList([]string{"foo", "bar"}, "and") => "foo and bar"
+// WordList([]string{"foo", "bar", "baz"}, "or") => "foo, bar, or baz"
+func WordList(words []string, conjunction string) string {
+	length := len(words)
+	switch length {
+	case 0:
+		return ""
+	case 1:
+		return words[0]
+	case 2:
+		return words[0] + " " + conjunction + " " + words[1]
+	default:
+		return fmt.Sprintf("%s, %s %s", strings.Join(words[:length-1], ", "), conjunction, words[length-1])
+	}
+}

--- a/util/string_utils_test.go
+++ b/util/string_utils_test.go
@@ -80,3 +80,44 @@ func TestPrefixString(t *testing.T) {
 		})
 	}
 }
+
+func TestWordList(t *testing.T) {
+	tests := []struct {
+		name        string
+		words       []string
+		conjunction string
+		expected    string
+	}{
+		{
+			name:        "empty word list",
+			words:       []string{},
+			conjunction: "and",
+			expected:    "",
+		},
+		{
+			name:        "single word",
+			words:       []string{"foo"},
+			conjunction: "and",
+			expected:    "foo",
+		},
+		{
+			name:        "two words",
+			words:       []string{"foo", "bar"},
+			conjunction: "and",
+			expected:    "foo and bar",
+		},
+		{
+			name:        "three words",
+			words:       []string{"foo", "bar", "baz"},
+			conjunction: "or",
+			expected:    "foo, bar, or baz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := util.WordList(tt.words, tt.conjunction)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
There are *no* functional changes; all changes only affect the comments inside `values.yaml`.

For each instance group that has a feature flag condition this change adds a comment to the `sizing.INSTANCEGROUP.count` field, e.g.

```
sizing:
  diego_api:
    ...
    # The diego_api instance group can be disabled by the eirini feature.
    # It can scale between 1 and 3 instances.
    # For high availability it needs at least 2 instances.
    count: 1
```

Each feature flag is also annotated with the list of instance groups it controls, e.g.

```
enable:
  # The eirini feature enables these instance groups: eirini
  # It disables these instance groups: diego_api, diego_brain, diego_ssh, and
  # diego_cell
  eirini: false
```

Additional minor changes are adding the conjunctive "and" in the list of 2 or more jobs, and using the proper format for the instance group names (underscores instead of dashes, `credhub_user` instead of `credhub-user`).