### PR TITLE
Ingress default values

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -755,10 +755,7 @@ func (f *Fissile) GenerateKube(settings kube.ExportSettings) error {
 	}
 
 	if settings.CreateHelmChart {
-		values, err := kube.MakeValues(settings)
-		if err != nil {
-			return err
-		}
+		values := kube.MakeValues(settings)
 		err = f.writeHelmNode(settings.OutputDir, "values.yaml", values)
 		if err != nil {
 			return err

--- a/kube/service.go
+++ b/kube/service.go
@@ -257,8 +257,8 @@ func newService(role *model.InstanceGroup, job *model.JobReference, serviceType 
 	service.Add("spec", spec.Sort())
 
 	if settings.CreateHelmChart && serviceType == newServiceTypePublic {
-		block := `if and .Values.services.loadbalanced .Values.services.ingress`
-		fail := `{{ fail "services.loadbalanced and services.ingress cannot both be set" }}`
+		block := `if and .Values.services.loadbalanced .Values.ingress.enabled`
+		fail := `{{ fail "services.loadbalanced and ingress.enabled cannot both be set" }}`
 		service.Add("_incompatible", fail, helm.Block(block))
 	}
 

--- a/kube/service.go
+++ b/kube/service.go
@@ -221,7 +221,7 @@ func newService(role *model.InstanceGroup, job *model.JobReference, serviceType 
 	}
 	if serviceType == newServiceTypePublic {
 		if settings.CreateHelmChart {
-			spec.Add("externalIPs", "{{ .Values.kube.external_ips | toJson }}", helm.Block("if not (or .Values.services.loadbalanced .Values.services.ingress)"))
+			spec.Add("externalIPs", "{{ .Values.kube.external_ips | toJson }}", helm.Block("if not (or .Values.services.loadbalanced .Values.ingress.enabled)"))
 			spec.Add("type", "LoadBalancer", helm.Block("if .Values.services.loadbalanced"))
 		} else {
 			spec.Add("externalIPs", []string{"192.168.77.77"})

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -296,44 +296,6 @@ func TestIstioManagedServiceHelm(t *testing.T) {
 					app.kubernetes.io/component: "myrole"
 		`, actual)
 	})
-
-	t.Run("Ingress", func(t *testing.T) {
-		t.Parallel()
-		config := map[string]interface{}{
-			"Values.services.ingress": "nic",
-			"Values.config.use_istio": true,
-		}
-		actual, err := RoundtripNode(service, config)
-		require.NoError(t, err)
-		testhelpers.IsYAMLEqualString(assert, `---
-			apiVersion: "v1"
-			kind: "Service"
-			metadata:
-				name: "myrole-tor"
-				labels:
-					app: myrole-tor
-					app.kubernetes.io/component: myrole-tor
-					app.kubernetes.io/instance: MyRelease
-					app.kubernetes.io/managed-by: Tiller
-					app.kubernetes.io/name: MyChart
-					app.kubernetes.io/version: 1.22.333.4444
-					helm.sh/chart: MyChart-42.1_foo
-					skiff-role-name: "myrole-tor"
-			spec:
-				ports:
-				-	name: "http"
-					port: 80
-					protocol: "TCP"
-					targetPort: 8080
-				-	name: "https"
-					port: 443
-					protocol: "TCP"
-					targetPort: 443
-				selector:
-					app: myrole
-					app.kubernetes.io/component: "myrole"
-		`, actual)
-	})
 }
 
 func TestHeadlessServiceKube(t *testing.T) {

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -167,7 +167,7 @@ func TestServiceHelm(t *testing.T) {
 	t.Run("Ingress", func(t *testing.T) {
 		t.Parallel()
 		config := map[string]interface{}{
-			"Values.services.ingress": "nic",
+			"Values.ingress.enabled": true,
 		}
 		actual, err := RoundtripNode(service, config)
 		require.NoError(t, err)
@@ -431,7 +431,7 @@ func TestHeadlessServiceHelm(t *testing.T) {
 	t.Run("Ingress", func(t *testing.T) {
 		t.Parallel()
 		config := map[string]interface{}{
-			"Values.services.ingress": "nic",
+			"Values.ingress.enabled": true,
 		}
 		actual, err := RoundtripNode(service, config)
 		require.NoError(t, err)
@@ -589,7 +589,7 @@ func TestPublicServiceHelm(t *testing.T) {
 		config := map[string]interface{}{
 			"Values.kube.external_ips":     "[127.0.0.1,127.0.0.2]",
 			"Values.services.loadbalanced": "true",
-			"Values.services.ingress":      "nic",
+			"Values.ingress.enabled":       true,
 		}
 
 		_, err := RoundtripNode(service, config)
@@ -600,7 +600,7 @@ func TestPublicServiceHelm(t *testing.T) {
 		t.Parallel()
 		config := map[string]interface{}{
 			"Values.kube.external_ips": "[127.0.0.1,127.0.0.2]",
-			"Values.services.ingress":  "nic",
+			"Values.ingress.enabled":   true,
 		}
 
 		actual, err := RoundtripNode(service, config)

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -214,7 +214,5 @@ func MakeBasicValues() *helm.Mapping {
 		"env", helm.NewMapping(),
 		"sizing", helm.NewMapping(),
 		"secrets", helm.NewMapping(),
-		"services", helm.NewMapping(
-			"loadbalanced", false,
-			"ingress", nil))
+		"services", helm.NewMapping("loadbalanced", false))
 }

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -214,5 +214,6 @@ func MakeBasicValues() *helm.Mapping {
 		"env", helm.NewMapping(),
 		"sizing", helm.NewMapping(),
 		"secrets", helm.NewMapping(),
-		"services", helm.NewMapping("loadbalanced", false))
+		"services", helm.NewMapping("loadbalanced", false),
+		"ingress", helm.NewMapping("enabled", false))
 }

--- a/kube/values.go
+++ b/kube/values.go
@@ -266,7 +266,7 @@ func MakeValues(settings ExportSettings) helm.Node {
 	values.Add("enable", enable.Sort())
 
 	ingress := helm.NewMapping()
-	ingress.Add("annotations", helm.NewMapping(), helm.Comment("ingress.annotations specify custom ingress annotations that gets merged to the default annotations."))
+	ingress.Add("annotations", helm.NewMapping(), helm.Comment("ingress.annotations allows specifying custom ingress annotations that gets merged to the default annotations."))
 	ingress.Add("enabled", false, helm.Comment("ingress.enabled enables ingress support - working ingress controller necessary."))
 	ingress.Add("tls", helm.NewMapping(), helm.Comment("ingress.tls.crt and ingress.tls.key, when specified, are used by the TLS secret for the Ingress resource."))
 	values.Add("ingress", ingress.Sort())

--- a/kube/values.go
+++ b/kube/values.go
@@ -22,8 +22,8 @@ func formattedExample(example string) string {
 	return example
 }
 
-// MakeValues returns a Mapping with all default values for the Helm chart
-func MakeValues(settings ExportSettings) (helm.Node, error) {
+// MakeValues returns a Mapping with all default values for the Helm chart.
+func MakeValues(settings ExportSettings) helm.Node {
 	values := MakeBasicValues()
 	env := helm.NewMapping()
 	secrets := helm.NewMapping()
@@ -265,5 +265,5 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 	}
 	values.Add("enable", enable.Sort())
 
-	return values, nil
+	return values
 }

--- a/kube/values.go
+++ b/kube/values.go
@@ -265,5 +265,11 @@ func MakeValues(settings ExportSettings) helm.Node {
 	}
 	values.Add("enable", enable.Sort())
 
+	ingress := helm.NewMapping()
+	ingress.Add("annotations", helm.NewMapping(), helm.Comment("ingress.annotations specify custom ingress annotations that gets merged to the default annotations."))
+	ingress.Add("enabled", false, helm.Comment("ingress.enabled enables ingress support - working ingress controller necessary."))
+	ingress.Add("tls", helm.NewMapping(), helm.Comment("ingress.tls.crt and ingress.tls.key, when specified, are used by the TLS secret for the Ingress resource."))
+	values.Add("ingress", ingress.Sort())
+
 	return values
 }

--- a/kube/values_test.go
+++ b/kube/values_test.go
@@ -137,4 +137,35 @@ func TestMakeValues(t *testing.T) {
 
 		assert.Equal(t, auth.String(), authString)
 	})
+
+	t.Run("Ingress", func(t *testing.T) {
+		t.Parallel()
+
+		expected := `---
+
+# ingress.annotations specify custom ingress annotations that gets merged to the
+# default annotations.
+annotations: {}
+
+# ingress.enabled enables ingress support - working ingress controller
+# necessary.
+enabled: false
+
+# ingress.tls.crt and ingress.tls.key, when specified, are used by the TLS
+# secret for the Ingress resource.
+tls: {}
+`
+
+		settings := ExportSettings{
+			RoleManifest: &model.RoleManifest{
+				InstanceGroups: model.InstanceGroups{},
+				Configuration:  &model.Configuration{},
+			},
+		}
+		node := MakeValues(settings)
+		require.NotNil(t, node)
+		actual := node.Get("ingress").String()
+
+		assert.Exactly(t, expected, actual)
+	})
 }

--- a/kube/values_test.go
+++ b/kube/values_test.go
@@ -36,13 +36,10 @@ func TestMakeValues(t *testing.T) {
 		}
 
 		node := MakeValues(settings)
-
-		assert.NotNil(t, node)
+		require.NotNil(t, node)
 
 		actual, err := RoundtripKube(node)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
 		testhelpers.IsYAMLSubsetString(assert.New(t), `---
 			sizing:
 				arole:
@@ -85,8 +82,7 @@ func TestMakeValues(t *testing.T) {
 		}
 
 		node := MakeValues(settings)
-
-		assert.NotNil(t, node)
+		require.NotNil(t, node)
 
 		registry := node.Get("kube").Get("registry").Get("hostname")
 
@@ -105,8 +101,7 @@ func TestMakeValues(t *testing.T) {
 		settings.Registry = "example.com"
 
 		node := MakeValues(settings)
-
-		assert.NotNil(t, node)
+		require.NotNil(t, node)
 
 		registry := node.Get("kube").Get("registry").Get("hostname")
 
@@ -123,8 +118,7 @@ func TestMakeValues(t *testing.T) {
 		}
 
 		node := MakeValues(settings)
-
-		assert.NotNil(t, node)
+		require.NotNil(t, node)
 
 		auth := node.Get("kube").Get("auth")
 
@@ -145,8 +139,7 @@ func TestMakeValues(t *testing.T) {
 		settings.AuthType = authString
 
 		node := MakeValues(settings)
-
-		assert.NotNil(t, node)
+		require.NotNil(t, node)
 
 		auth := node.Get("kube").Get("auth")
 

--- a/kube/values_test.go
+++ b/kube/values_test.go
@@ -35,10 +35,9 @@ func TestMakeValues(t *testing.T) {
 			},
 		}
 
-		node, err := MakeValues(settings)
+		node := MakeValues(settings)
 
 		assert.NotNil(t, node)
-		assert.NoError(t, err)
 
 		actual, err := RoundtripKube(node)
 		if !assert.NoError(t, err) {
@@ -68,8 +67,7 @@ func TestMakeValues(t *testing.T) {
 			},
 		}
 
-		node, err := MakeValues(settings)
-		assert.NoError(t, err)
+		node := MakeValues(settings)
 		require.NotNil(t, node)
 
 		sizing := node.Get("sizing")
@@ -86,10 +84,9 @@ func TestMakeValues(t *testing.T) {
 			},
 		}
 
-		node, err := MakeValues(settings)
+		node := MakeValues(settings)
 
 		assert.NotNil(t, node)
-		assert.NoError(t, err)
 
 		registry := node.Get("kube").Get("registry").Get("hostname")
 
@@ -107,10 +104,9 @@ func TestMakeValues(t *testing.T) {
 
 		settings.Registry = "example.com"
 
-		node, err := MakeValues(settings)
+		node := MakeValues(settings)
 
 		assert.NotNil(t, node)
-		assert.NoError(t, err)
 
 		registry := node.Get("kube").Get("registry").Get("hostname")
 
@@ -126,10 +122,9 @@ func TestMakeValues(t *testing.T) {
 			},
 		}
 
-		node, err := MakeValues(settings)
+		node := MakeValues(settings)
 
 		assert.NotNil(t, node)
-		assert.NoError(t, err)
 
 		auth := node.Get("kube").Get("auth")
 
@@ -149,10 +144,9 @@ func TestMakeValues(t *testing.T) {
 
 		settings.AuthType = authString
 
-		node, err := MakeValues(settings)
+		node := MakeValues(settings)
 
 		assert.NotNil(t, node)
-		assert.NoError(t, err)
 
 		auth := node.Get("kube").Get("auth")
 

--- a/kube/values_test.go
+++ b/kube/values_test.go
@@ -67,8 +67,9 @@ func TestMakeValues(t *testing.T) {
 	t.Run("Check Default Registry", func(t *testing.T) {
 		t.Parallel()
 		settings := ExportSettings{
-			RoleManifest: &model.RoleManifest{InstanceGroups: model.InstanceGroups{},
-				Configuration: &model.Configuration{},
+			RoleManifest: &model.RoleManifest{
+				InstanceGroups: model.InstanceGroups{},
+				Configuration:  &model.Configuration{},
 			},
 		}
 
@@ -83,8 +84,9 @@ func TestMakeValues(t *testing.T) {
 	t.Run("Check Custom Registry", func(t *testing.T) {
 		t.Parallel()
 		settings := ExportSettings{
-			RoleManifest: &model.RoleManifest{InstanceGroups: model.InstanceGroups{},
-				Configuration: &model.Configuration{},
+			RoleManifest: &model.RoleManifest{
+				InstanceGroups: model.InstanceGroups{},
+				Configuration:  &model.Configuration{},
 			},
 		}
 
@@ -101,8 +103,9 @@ func TestMakeValues(t *testing.T) {
 	t.Run("Check Default Auth", func(t *testing.T) {
 		t.Parallel()
 		settings := ExportSettings{
-			RoleManifest: &model.RoleManifest{InstanceGroups: model.InstanceGroups{},
-				Configuration: &model.Configuration{},
+			RoleManifest: &model.RoleManifest{
+				InstanceGroups: model.InstanceGroups{},
+				Configuration:  &model.Configuration{},
 			},
 		}
 
@@ -117,8 +120,9 @@ func TestMakeValues(t *testing.T) {
 	t.Run("Check Custom Auth", func(t *testing.T) {
 		t.Parallel()
 		settings := ExportSettings{
-			RoleManifest: &model.RoleManifest{InstanceGroups: model.InstanceGroups{},
-				Configuration: &model.Configuration{},
+			RoleManifest: &model.RoleManifest{
+				InstanceGroups: model.InstanceGroups{},
+				Configuration:  &model.Configuration{},
 			},
 		}
 

--- a/kube/values_test.go
+++ b/kube/values_test.go
@@ -1,8 +1,6 @@
 package kube
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"code.cloudfoundry.org/fissile/model"
@@ -14,14 +12,9 @@ import (
 func TestMakeValues(t *testing.T) {
 	t.Parallel()
 
-	outDir, err := ioutil.TempDir("", "fissile-generate-auth-")
-	require.NoError(t, err)
-	defer os.RemoveAll(outDir)
-
 	t.Run("Capabilities", func(t *testing.T) {
 		t.Parallel()
 		settings := ExportSettings{
-			OutputDir: outDir,
 			RoleManifest: &model.RoleManifest{
 				InstanceGroups: model.InstanceGroups{
 					&model.InstanceGroup{
@@ -50,7 +43,6 @@ func TestMakeValues(t *testing.T) {
 	t.Run("Sizing", func(t *testing.T) {
 		t.Parallel()
 		settings := ExportSettings{
-			OutputDir: outDir,
 			RoleManifest: &model.RoleManifest{
 				InstanceGroups: model.InstanceGroups{
 					&model.InstanceGroup{
@@ -75,7 +67,6 @@ func TestMakeValues(t *testing.T) {
 	t.Run("Check Default Registry", func(t *testing.T) {
 		t.Parallel()
 		settings := ExportSettings{
-			OutputDir: outDir,
 			RoleManifest: &model.RoleManifest{InstanceGroups: model.InstanceGroups{},
 				Configuration: &model.Configuration{},
 			},
@@ -92,7 +83,6 @@ func TestMakeValues(t *testing.T) {
 	t.Run("Check Custom Registry", func(t *testing.T) {
 		t.Parallel()
 		settings := ExportSettings{
-			OutputDir: outDir,
 			RoleManifest: &model.RoleManifest{InstanceGroups: model.InstanceGroups{},
 				Configuration: &model.Configuration{},
 			},
@@ -111,7 +101,6 @@ func TestMakeValues(t *testing.T) {
 	t.Run("Check Default Auth", func(t *testing.T) {
 		t.Parallel()
 		settings := ExportSettings{
-			OutputDir: outDir,
 			RoleManifest: &model.RoleManifest{InstanceGroups: model.InstanceGroups{},
 				Configuration: &model.Configuration{},
 			},
@@ -128,7 +117,6 @@ func TestMakeValues(t *testing.T) {
 	t.Run("Check Custom Auth", func(t *testing.T) {
 		t.Parallel()
 		settings := ExportSettings{
-			OutputDir: outDir,
 			RoleManifest: &model.RoleManifest{InstanceGroups: model.InstanceGroups{},
 				Configuration: &model.Configuration{},
 			},

--- a/kube/values_test.go
+++ b/kube/values_test.go
@@ -143,8 +143,8 @@ func TestMakeValues(t *testing.T) {
 
 		expected := `---
 
-# ingress.annotations specify custom ingress annotations that gets merged to the
-# default annotations.
+# ingress.annotations allows specifying custom ingress annotations that gets
+# merged to the default annotations.
 annotations: {}
 
 # ingress.enabled enables ingress support - working ingress controller


### PR DESCRIPTION
## Description

- Added ingress default values with comments.
- Updated values_test.go.

## Test plan

Fissile should generate the `values.yaml` with the specified ingress default values (as seen on the unit test).