### PR TITLE
Replace deprecated storage-class annotation with storageClassName key.

### DIFF
--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -170,14 +170,13 @@ func TestPodGetVolumes(t *testing.T) {
 			expected: `---
 				metadata:
 					name: persistent-volume
-					annotations:
-						volume.beta.kubernetes.io/storage-class: persistent
 				spec:
 					accessModes:
 					-	ReadWriteOnce
 					resources:
 						requests:
-							storage: 5G`,
+							storage: 5G
+					storageClassName:	persistent`,
 		},
 		{
 			desc:  "sharedClaim",
@@ -185,14 +184,13 @@ func TestPodGetVolumes(t *testing.T) {
 			expected: `---
 				metadata:
 					name: shared-volume
-					annotations:
-						volume.beta.kubernetes.io/storage-class: shared
 				spec:
 					accessModes:
 					-	ReadWriteMany
 					resources:
 						requests:
-							storage: 40G`,
+							storage: 40G
+					storageClassName:	shared`,
 		},
 	}
 	for _, sample := range samples {
@@ -245,14 +243,13 @@ func TestPodGetVolumesHelm(t *testing.T) {
 		testhelpers.IsYAMLEqualString(assert, `---
 		metadata:
 			name: "persistent-volume"
-			annotations:
-				volume.beta.kubernetes.io/storage-class: "Persistent"
 		spec:
 			accessModes:
 			-	"ReadWriteOnce"
 			resources:
 				requests:
 					storage: "42G"
+			storageClassName:	"Persistent"
 		`, actual)
 	}
 
@@ -261,14 +258,13 @@ func TestPodGetVolumesHelm(t *testing.T) {
 		testhelpers.IsYAMLEqualString(assert, `---
 		metadata:
 			name: "shared-volume"
-			annotations:
-				volume.beta.kubernetes.io/storage-class: "Shared"
 		spec:
 			accessModes:
 			-	"ReadWriteMany"
 			resources:
 				requests:
 					storage: "84G"
+			storageClassName:	"Shared"
 		`, actual)
 	}
 }

--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -87,11 +87,7 @@ func getVolumeClaims(role *model.InstanceGroup, createHelmChart bool) []helm.Nod
 
 		meta := helm.NewMapping("name", volume.Tag)
 		if len(volume.Annotations) > 0 {
-			annotationList := helm.NewMapping()
-			for key, value := range volume.Annotations {
-				annotationList.Add(key, value)
-			}
-			meta.Add("annotations", annotationList)
+			meta.Add("annotations", helm.NewNode(volume.Annotations))
 		}
 
 		var size string

--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -88,22 +88,10 @@ func getVolumeClaims(role *model.InstanceGroup, createHelmChart bool) []helm.Nod
 		meta := helm.NewMapping("name", volume.Tag)
 		if len(volume.Annotations) > 0 {
 			annotationList := helm.NewMapping()
-			haveAnnotations := false
 			for key, value := range volume.Annotations {
-				// Detect and convert a storage-class annotation in the role-manifest to
-				// a regular storage class name. Needed because such an annotation is the
-				// only way for the role manifest to override the type-derived storage
-				// class, yet we must not emit this specific annotation anymore.
-				if key == VolumeStorageClassAnnotation {
-					storageClass = value
-					continue
-				}
 				annotationList.Add(key, value)
-				haveAnnotations = true
 			}
-			if haveAnnotations {
-				meta.Add("annotations", annotationList)
-			}
+			meta.Add("annotations", annotationList)
 		}
 
 		var size string

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -484,24 +484,22 @@ func TestStatefulSetVolumesKube(t *testing.T) {
 			volumeClaimTemplates:
 				-
 					metadata:
-						annotations:
-							volume.beta.kubernetes.io/storage-class: persistent
 						name: persistent-volume
 					spec:
 						accessModes: [ReadWriteOnce]
 						resources:
 							requests:
 								storage: 5G
+						storageClassName:	persistent
 				-
 					metadata:
-						annotations:
-							volume.beta.kubernetes.io/storage-class: shared
 						name: shared-volume
 					spec:
 						accessModes: [ReadWriteMany]
 						resources:
 							requests:
 								storage: 40G
+						storageClassName:	shared
 	`
 	testhelpers.IsYAMLSubsetString(assert, expected, actual)
 }
@@ -571,7 +569,6 @@ func TestStatefulSetVolumesWithAnnotationKube(t *testing.T) {
 				-
 					metadata:
 						annotations:
-							volume.beta.kubernetes.io/storage-class: a-company-file-gold
 							volume.beta.kubernetes.io/storage-provisioner: a-company.io/storage-provisioner
 						name: persistent-volume
 					spec:
@@ -579,10 +576,10 @@ func TestStatefulSetVolumesWithAnnotationKube(t *testing.T) {
 						resources:
 							requests:
 								storage: 5G
+						storageClassName:	a-company-file-gold
 				-
 					metadata:
 						annotations:
-							volume.beta.kubernetes.io/storage-class: shared
 							volume.beta.kubernetes.io/storage-provisioner: a-company.io/storage-provisioner
 						name: shared-volume
 					spec:
@@ -590,6 +587,7 @@ func TestStatefulSetVolumesWithAnnotationKube(t *testing.T) {
 						resources:
 							requests:
 								storage: 40G
+						storageClassName:	shared
 	`
 	testhelpers.IsYAMLSubsetString(assert, expected, actual)
 }
@@ -674,24 +672,22 @@ func TestStatefulSetVolumesHelm(t *testing.T) {
 			volumeClaimTemplates:
 				-
 					metadata:
-						annotations:
-							volume.beta.kubernetes.io/storage-class: persistent
 						name: persistent-volume
 					spec:
 						accessModes: [ReadWriteOnce]
 						resources:
 							requests:
 								storage: 5G
+						storageClassName:	persistent
 				-
 					metadata:
-						annotations:
-							volume.beta.kubernetes.io/storage-class: shared
 						name: shared-volume
 					spec:
 						accessModes: [ReadWriteMany]
 						resources:
 							requests:
 								storage: 40G
+						storageClassName:	shared
 	`
 	testhelpers.IsYAMLSubsetString(assert, expected, actual)
 
@@ -793,14 +789,13 @@ func TestStatefulSetEmptyDirVolumesKube(t *testing.T) {
 			volumeClaimTemplates:
 				-
 					metadata:
-						annotations:
-							volume.beta.kubernetes.io/storage-class: persistent
 						name: persistent-volume
 					spec:
 						accessModes: [ReadWriteOnce]
 						resources:
 							requests:
 								storage: 5G
+						storageClassName:	persistent
 	`
 	testhelpers.IsYAMLSubsetString(assert, expected, actual)
 }

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -569,6 +569,7 @@ func TestStatefulSetVolumesWithAnnotationKube(t *testing.T) {
 				-
 					metadata:
 						annotations:
+							volume.beta.kubernetes.io/storage-class: a-company-file-gold
 							volume.beta.kubernetes.io/storage-provisioner: a-company.io/storage-provisioner
 						name: persistent-volume
 					spec:
@@ -576,7 +577,7 @@ func TestStatefulSetVolumesWithAnnotationKube(t *testing.T) {
 						resources:
 							requests:
 								storage: 5G
-						storageClassName:	a-company-file-gold
+						storageClassName:	persistent
 				-
 					metadata:
 						annotations:


### PR DESCRIPTION
Ref: https://trello.com/c/rhJZ3Rqm/1036-dont-use-deprecated-storage-class-key-in-helm-templates
