### PR TITLE
Renamed JobReference fields for consistency

### DIFF
--- a/model/job_reference.go
+++ b/model/job_reference.go
@@ -10,8 +10,8 @@ type JobReference struct {
 	*Job                `yaml:"-"`                 // The resolved job
 	Name                string                     `yaml:"name"`    // The name of the job
 	ReleaseName         string                     `yaml:"release"` // The release the job comes from
-	ExportedProviders   map[string]JobProvidesInfo `yaml:"provides"`
-	ResolvedConsumers   map[string]JobConsumesInfo `yaml:"consumes"`    // Instance groups that this job links to & requires
+	ExportedProvides    map[string]JobProvidesInfo `yaml:"provides"`
+	ResolvedConsumes    map[string]JobConsumesInfo `yaml:"consumes"`    // Instance groups that this job links to & requires
 	ResolvedConsumedBy  map[string][]JobLinkInfo   `yaml:"consumed_by"` // Instance groups that consume a link
 	ContainerProperties JobContainerProperties     `yaml:"properties"`
 }
@@ -197,7 +197,7 @@ func (j *JobReference) WriteConfigs(instanceGroup *InstanceGroup, lightOpinionsP
 
 	config.Job.Name = instanceGroup.Name
 
-	for _, consumer := range j.ResolvedConsumers {
+	for _, consumer := range j.ResolvedConsumes {
 		config.Consumes[consumer.Name] = consumer.JobLinkInfo
 	}
 	config.ConsumedBy = j.ResolvedConsumedBy

--- a/model/job_reference_test.go
+++ b/model/job_reference_test.go
@@ -44,7 +44,7 @@ func TestWriteConfigs(t *testing.T) {
 			{
 				Job:  job,
 				Name: "silly job",
-				ResolvedConsumers: map[string]JobConsumesInfo{
+				ResolvedConsumes: map[string]JobConsumesInfo{
 					"serious": JobConsumesInfo{
 						JobLinkInfo: JobLinkInfo{
 							Name:     "serious",

--- a/model/resolver/resolver.go
+++ b/model/resolver/resolver.go
@@ -262,7 +262,7 @@ func (r *Resolver) ResolveLinks() validation.ErrorList {
 					})
 				}
 			}
-			for name, provider := range jobReference.ExportedProviders {
+			for name, provider := range jobReference.ExportedProvides {
 				info, ok := jobReference.Job.AvailableProviders[name]
 				if !ok {
 					errors = append(errors, validation.NotFound(
@@ -293,7 +293,7 @@ func (r *Resolver) ResolveLinks() validation.ErrorList {
 			expectedConsumers := make([]model.JobConsumesInfo, len(jobReference.Job.DesiredConsumers))
 			copy(expectedConsumers, jobReference.Job.DesiredConsumers)
 			// Deal with any explicitly marked consumers in the role manifest
-			for consumerName, consumerInfo := range jobReference.ResolvedConsumers {
+			for consumerName, consumerInfo := range jobReference.ResolvedConsumes {
 				consumerAlias := consumerName
 				if consumerInfo.Alias != "" {
 					consumerAlias = consumerInfo.Alias
@@ -313,7 +313,7 @@ func (r *Resolver) ResolveLinks() validation.ErrorList {
 						fmt.Sprintf(`consumer %s not found`, consumerAlias)))
 					continue
 				}
-				jobReference.ResolvedConsumers[consumerName] = model.JobConsumesInfo{
+				jobReference.ResolvedConsumes[consumerName] = model.JobConsumesInfo{
 					JobLinkInfo: provider.JobLinkInfo,
 				}
 
@@ -343,13 +343,13 @@ func (r *Resolver) ResolveLinks() validation.ErrorList {
 					if name == "" {
 						name = provider.Name
 					}
-					info := jobReference.ResolvedConsumers[name]
+					info := jobReference.ResolvedConsumes[name]
 					info.Name = provider.Name
 					info.Type = provider.Type
 					info.RoleName = provider.RoleName
 					info.JobName = provider.JobName
 					info.ServiceName = provider.ServiceName
-					jobReference.ResolvedConsumers[name] = info
+					jobReference.ResolvedConsumes[name] = info
 				} else if !consumerInfo.Optional {
 					errors = append(errors, validation.Required(
 						fmt.Sprintf(`instance_group[%s].job[%s].consumes[%s]`, instanceGroup.Name, jobReference.Name, consumerInfo.Name),
@@ -371,7 +371,7 @@ func (r *Resolver) recordJobConsumers(m *model.RoleManifest) validation.ErrorLis
 
 	for _, consumerInstanceGroup := range m.InstanceGroups {
 		for _, consumerJob := range consumerInstanceGroup.JobReferences {
-			for linkName, consumer := range consumerJob.ResolvedConsumers {
+			for linkName, consumer := range consumerJob.ResolvedConsumes {
 				providerInstanceGroup := m.LookupInstanceGroup(consumer.RoleName)
 				if providerInstanceGroup == nil {
 					// This should not happen: we resolved a link, but can no

--- a/model/resolver/resolver_test.go
+++ b/model/resolver/resolver_test.go
@@ -690,7 +690,7 @@ func TestResolveLinks(t *testing.T) {
 		for _, expected := range samples {
 			t.Run("", func(t *testing.T) {
 				if expected.Missing {
-					for name, consumeInfo := range job.ResolvedConsumers {
+					for name, consumeInfo := range job.ResolvedConsumes {
 						assert.NotEqual(t, expected.Type, consumeInfo.Type,
 							"link should not resolve, got %s (type %s) in %s / %s",
 							name, consumeInfo.Type, consumeInfo.RoleName, consumeInfo.JobName)
@@ -698,15 +698,15 @@ func TestResolveLinks(t *testing.T) {
 					return
 				}
 				expectedLength++
-				require.Contains(t, job.ResolvedConsumers, expected.Name, "link %s is missing", expected.Name)
-				actual := job.ResolvedConsumers[expected.Name]
+				require.Contains(t, job.ResolvedConsumes, expected.Name, "link %s is missing", expected.Name)
+				actual := job.ResolvedConsumes[expected.Name]
 				assert.Equal(t, expected.Name, actual.Name, "link name mismatch")
 				assert.Equal(t, expected.Type, actual.Type, "link type mismatch")
 				assert.Equal(t, role.Name, actual.RoleName, "link role name mismatch")
 				assert.Equal(t, job.Name, actual.JobName, "link job name mismatch")
 			})
 		}
-		assert.Len(t, job.ResolvedConsumers, expectedLength)
+		assert.Len(t, job.ResolvedConsumes, expectedLength)
 	})
 
 	t.Run("consumed-by", func(t *testing.T) {
@@ -850,7 +850,7 @@ func TestRoleResolveLinksMultipleProvider(t *testing.T) {
 				JobReferences: model.JobReferences{
 					{
 						Job: job1,
-						ExportedProviders: map[string]model.JobProvidesInfo{
+						ExportedProvides: map[string]model.JobProvidesInfo{
 							"job-1-provider-3": model.JobProvidesInfo{
 								Alias: "unique-alias",
 							},
@@ -871,10 +871,10 @@ func TestRoleResolveLinksMultipleProvider(t *testing.T) {
 					{
 						Job: job3,
 						// This has an explicitly exported provider
-						ExportedProviders: map[string]model.JobProvidesInfo{
+						ExportedProvides: map[string]model.JobProvidesInfo{
 							"job-3-provider-3": model.JobProvidesInfo{},
 						},
-						ResolvedConsumers: map[string]model.JobConsumesInfo{
+						ResolvedConsumes: map[string]model.JobConsumesInfo{
 							"actual-consumer-name": model.JobConsumesInfo{
 								Alias: "unique-alias",
 							},
@@ -892,8 +892,8 @@ func TestRoleResolveLinksMultipleProvider(t *testing.T) {
 	for _, r := range roleManifest.InstanceGroups {
 		for _, jobReference := range r.JobReferences {
 			jobReference.Name = jobReference.Job.Name
-			if jobReference.ResolvedConsumers == nil {
-				jobReference.ResolvedConsumers = make(map[string]model.JobConsumesInfo)
+			if jobReference.ResolvedConsumes == nil {
+				jobReference.ResolvedConsumes = make(map[string]model.JobConsumesInfo)
 			}
 			if jobReference.ResolvedConsumedBy == nil {
 				jobReference.ResolvedConsumedBy = make(map[string][]model.JobLinkInfo)
@@ -906,7 +906,7 @@ func TestRoleResolveLinksMultipleProvider(t *testing.T) {
 	require.NotNil(role, "Failed to find role")
 	job := role.LookupJob("job-3")
 	require.NotNil(job, "Failed to find job")
-	consumes := job.ResolvedConsumers
+	consumes := job.ResolvedConsumes
 
 	assert.Len(consumes, 3, "incorrect number of resulting link consumers")
 

--- a/model/resolver/validation.go
+++ b/model/resolver/validation.go
@@ -45,14 +45,14 @@ func validateInstanceGroup(roleManifest *model.RoleManifest, g *model.InstanceGr
 		}
 		jobReference.Job = job
 
-		if jobReference.ResolvedConsumers == nil {
+		if jobReference.ResolvedConsumes == nil {
 			// No explicitly specified consumers
-			jobReference.ResolvedConsumers = make(map[string]model.JobConsumesInfo)
+			jobReference.ResolvedConsumes = make(map[string]model.JobConsumesInfo)
 		}
 
-		for name, info := range jobReference.ResolvedConsumers {
+		for name, info := range jobReference.ResolvedConsumes {
 			info.Name = name
-			jobReference.ResolvedConsumers[name] = info
+			jobReference.ResolvedConsumes[name] = info
 		}
 
 		if jobReference.ResolvedConsumedBy == nil {


### PR DESCRIPTION
Renamed `JobReference` fields for consistency with the YAML labels.