### PR TITLE
Don't generate imagePullSecrets when the username is empty

### DIFF
--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -199,6 +199,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 			"Values.sizing.some_group.affinity.nodeAffinity": "snafu",
 			"Values.sizing.some_group.capabilities":          []interface{}{},
 			"Values.kube.registry.hostname":                  "docker.suse.fake",
+			"Values.kube.registry.username":                  "", // no imagePullSecrets
 			"Values.kube.organization":                       "splat",
 			"Values.env.KUBERNETES_CLUSTER_DOMAIN":           "cluster.local",
 		}
@@ -291,8 +292,6 @@ func TestNewDeploymentHelm(t *testing.T) {
 								name: deployment-manifest
 								readOnly: true
 						dnsPolicy: "ClusterFirst"
-						imagePullSecrets:
-						- name: "registry-credentials"
 						restartPolicy: "Always"
 						terminationGracePeriodSeconds: 600
 						volumes:
@@ -338,6 +337,7 @@ func TestNewDeploymentIstioManagedHelm(t *testing.T) {
 			"Values.sizing.istio_managed_group.affinity.nodeAffinity": "snafu",
 			"Values.sizing.istio_managed_group.capabilities":          []interface{}{},
 			"Values.kube.registry.hostname":                           "docker.suse.fake",
+			"Values.kube.registry.username":                           "U",
 			"Values.kube.organization":                                "splat",
 			"Values.env.KUBERNETES_CLUSTER_DOMAIN":                    "cluster.local",
 		}

--- a/kube/job_test.go
+++ b/kube/job_test.go
@@ -150,6 +150,7 @@ func TestJobHelm(t *testing.T) {
 		"Template.BasePath":                    fakeTemplateDir,
 		"Release.Revision":                     "42",
 		"Values.kube.registry.hostname":        "docker.suse.fake",
+		"Values.kube.registry.username":        "U",
 		"Values.kube.organization":             "splat",
 		"Values.env.KUBERNETES_CLUSTER_DOMAIN": "cluster.local",
 		"Values.sizing.pre_role.capabilities":  []interface{}{},

--- a/kube/kube_test.go
+++ b/kube/kube_test.go
@@ -224,7 +224,12 @@ func getBasicConfig() (map[string]interface{}, error) {
 		switch n := node.(type) {
 		case *helm.Scalar:
 			var v interface{}
-			err := yaml.Unmarshal([]byte(n.String()), &v)
+			buffer := &bytes.Buffer{}
+			err := helm.NewEncoder(buffer).Encode(n)
+			if err != nil {
+				return nil, fmt.Errorf("Error encoding node at %s: %s", strings.Join(path, "."), err)
+			}
+			err = yaml.Unmarshal(buffer.Bytes(), &v)
 			if err != nil {
 				return nil, fmt.Errorf("Error parsing node at %s: %s", strings.Join(path, "."), err)
 			}

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -48,7 +48,9 @@ func NewPodTemplate(role *model.InstanceGroup, settings ExportSettings, grapher 
 		// This role requires a custom service account
 		spec.Add("serviceAccountName", role.Run.ServiceAccount, authModeRBAC(settings))
 	}
-
+	if settings.CreateHelmChart {
+		spec.Get("imagePullSecrets").Set(helm.Block(`if ne .Values.kube.registry.username ""`))
+	}
 	// BOSH can potentially have an infinite termination grace period; we don't
 	// really trust that, so we'll just go with ten minutes and hope it's enough
 	spec.Add("terminationGracePeriodSeconds", 600)

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -1785,6 +1785,7 @@ func TestPodPreFlightHelm(t *testing.T) {
 
 	config := map[string]interface{}{
 		"Values.kube.registry.hostname":        "R",
+		"Values.kube.registry.username":        "U",
 		"Values.kube.organization":             "O",
 		"Values.env.KUBERNETES_CLUSTER_DOMAIN": "cluster.local",
 		"Values.sizing.pre_role.capabilities":  []interface{}{},
@@ -1907,6 +1908,7 @@ func TestPodPostFlightHelm(t *testing.T) {
 
 	config := map[string]interface{}{
 		"Values.kube.registry.hostname":        "R",
+		"Values.kube.registry.username":        "U",
 		"Values.kube.organization":             "O",
 		"Values.env.KUBERNETES_CLUSTER_DOMAIN": "cluster.local",
 		"Values.sizing.post_role.capabilities": []interface{}{},
@@ -2038,6 +2040,7 @@ func TestPodMemoryHelmDisabled(t *testing.T) {
 	config := map[string]interface{}{
 		"Values.config.memory.requests":         nil,
 		"Values.kube.registry.hostname":         "R",
+		"Values.kube.registry.username":         "U",
 		"Values.kube.organization":              "O",
 		"Values.env.KUBERNETES_CLUSTER_DOMAIN":  "cluster.local",
 		"Values.sizing.pre_role.capabilities":   []interface{}{},
@@ -2134,6 +2137,7 @@ func TestPodMemoryHelmActive(t *testing.T) {
 		"Values.env.KUBERNETES_CLUSTER_DOMAIN":  "cluster.local",
 		"Values.kube.organization":              "O",
 		"Values.kube.registry.hostname":         "R",
+		"Values.kube.registry.username":         "U",
 		"Values.sizing.pre_role.capabilities":   []interface{}{},
 		"Values.sizing.pre_role.memory.limit":   "10",
 		"Values.sizing.pre_role.memory.request": "1",
@@ -2269,6 +2273,7 @@ func TestPodCPUHelmDisabled(t *testing.T) {
 		"Values.env.KUBERNETES_CLUSTER_DOMAIN": "cluster.local",
 		"Values.kube.organization":             "O",
 		"Values.kube.registry.hostname":        "R",
+		"Values.kube.registry.username":        "U",
 		"Values.sizing.pre_role.capabilities":  []interface{}{},
 		"Values.sizing.pre_role.cpu.request":   nil,
 	}
@@ -2363,6 +2368,7 @@ func TestPodCPUHelmActive(t *testing.T) {
 		"Values.env.KUBERNETES_CLUSTER_DOMAIN": "cluster.local",
 		"Values.kube.organization":             "O",
 		"Values.kube.registry.hostname":        "R",
+		"Values.kube.registry.username":        "U",
 		"Values.sizing.pre_role.capabilities":  []interface{}{},
 		"Values.sizing.pre_role.cpu.limit":     "10",
 		"Values.sizing.pre_role.cpu.request":   "1",
@@ -2946,6 +2952,7 @@ func TestPodIstioManagedHelm(t *testing.T) {
 	config := map[string]interface{}{
 		"Values.config.use_istio":                       "true",
 		"Values.kube.registry.hostname":                 "R",
+		"Values.kube.registry.username":                 "U",
 		"Values.kube.organization":                      "O",
 		"Values.env.KUBERNETES_CLUSTER_DOMAIN":          "cluster.local",
 		"Values.sizing.istio_managed_role.capabilities": []interface{}{},

--- a/kube/registry_credentials.go
+++ b/kube/registry_credentials.go
@@ -24,8 +24,8 @@ func MakeRegistryCredentials(settings ExportSettings) (helm.Node, error) {
 
 		value = `{{ printf "{%q:{%q:%q,%q:%q,%q:%q}}" ` +
 			`.Values.kube.registry.hostname ` +
-			`"username" (default "" .Values.kube.registry.username) ` +
-			`"password" (default "" .Values.kube.registry.password) ` +
+			`"username" .Values.kube.registry.username ` +
+			`"password" .Values.kube.registry.password ` +
 			`"auth" (printf "%s:%s" .Values.kube.registry.username .Values.kube.registry.password | b64enc) ` +
 			`| b64enc }}`
 	}

--- a/kube/registry_credentials.go
+++ b/kube/registry_credentials.go
@@ -37,6 +37,9 @@ func MakeRegistryCredentials(settings ExportSettings) (helm.Node, error) {
 		SetAPIVersion("v1").
 		SetKind("Secret").
 		SetName("registry-credentials")
+	if settings.CreateHelmChart {
+		cb.AddModifier(helm.Block(`if ne .Values.kube.registry.username ""`))
+	}
 	secret, err := cb.Build()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build a new kube config: %v", err)

--- a/kube/registry_credentials_test.go
+++ b/kube/registry_credentials_test.go
@@ -87,4 +87,12 @@ func TestMakeRegistryCredentialsHelm(t *testing.T) {
 				skiff-role-name: "registry-credentials"
 		type: "kubernetes.io/dockercfg"
 	`, dcfg), actual)
+
+	// registry credentials are only created when the username is set
+	config["Values.kube.registry.username"] = ""
+	actual, err = RoundtripNode(registryCredentials, config)
+	if !assert.NoError(err) {
+		return
+	}
+	assert.Nil(actual, "There should be no credentials when the username is empty")
 }


### PR DESCRIPTION
Fixes #487.

The template only checks for an empty username, so the same logic should apply to a private registry that doesn't require authentication.