### PR TITLE
scripts/readiness-probe: Be quieter

### DIFF
--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -97,7 +97,7 @@ func TestRunInContainer(t *testing.T) {
 	exitCode, container, err := dockerManager.RunInContainer(RunInContainerOpts{
 		ContainerName: getTestName(),
 		ImageName:     dockerImageName,
-		Cmd:           []string{"hostname"},
+		Cmd:           []string{"hostname", "--fqdn"},
 		StdoutWriter:  stdoutWriter,
 		StderrWriter:  stderrWriter,
 	})


### PR DESCRIPTION
Reduce the amount of detail when the readiness probe isn't ready, as too much irrelevant information was being emitted as things changed state.   Error messages about things like monitrc missing tend to end up being misleading when troubleshooting a broke installation.

Also fixes the docker test that is for some reason failing on my machine (but passing on CI).
