### PR TITLE
Set KUBE_SIZING_*_COUNT correctly when config.HA is true

### DIFF
--- a/kube/pod.go
+++ b/kube/pod.go
@@ -397,8 +397,7 @@ func getEnvVarsFromConfigs(configs model.Variables, settings ExportSettings) (he
 				return nil, fmt.Errorf("%s must not be a secret variable", config.Name)
 			}
 			if settings.CreateHelmChart {
-				value := fmt.Sprintf("{{ .Values.sizing.%s.count | quote }}", makeVarName(roleName))
-				envVar := helm.NewMapping("name", config.Name, "value", value)
+				envVar := helm.NewMapping("name", config.Name, "value", replicaCount(role, true))
 				env = append(env, envVar)
 			} else {
 				envVar := helm.NewMapping("name", config.Name, "value", strconv.Itoa(role.Run.Scaling.Min))

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -391,6 +391,12 @@ func TestPodGetEnvVarsFromConfigSizingCountHelm(t *testing.T) {
 			InstanceGroups: []*model.InstanceGroup{
 				&model.InstanceGroup{
 					Name: "foo",
+					Run: &model.RoleRun{
+						Scaling: &model.RoleRunScaling{
+							Min: 1,
+							HA:  7,
+						},
+					},
 				},
 			},
 		},
@@ -411,6 +417,28 @@ func TestPodGetEnvVarsFromConfigSizingCountHelm(t *testing.T) {
 					fieldPath: "metadata.namespace"
 		-	name: "KUBE_SIZING_FOO_COUNT"
 			value: "22"
+		-	name: "VCAP_HARD_NPROC"
+			value: "2048"
+		-	name: "VCAP_SOFT_NPROC"
+			value: "1024"
+	`, actual)
+
+	config = map[string]interface{}{
+		"Values.sizing.foo.count": 1, // Run.Scaling.Min
+		"Values.config.HA":        true,
+	}
+
+	actual, err = RoundtripNode(ev, config)
+	if !assert.NoError(err) {
+		return
+	}
+	testhelpers.IsYAMLEqualString(assert, `---
+		-	name: "KUBERNETES_NAMESPACE"
+			valueFrom:
+				fieldRef:
+					fieldPath: "metadata.namespace"
+		-	name: "KUBE_SIZING_FOO_COUNT"
+			value: "7"
 		-	name: "VCAP_HARD_NPROC"
 			value: "2048"
 		-	name: "VCAP_SOFT_NPROC"


### PR DESCRIPTION
It needs to use the same template logic as the replica setting in the statefulset spec.

The helm chart for SCF should change as follows:

```
         - name: "KUBE_SIZING_NATS_COUNT"
-          value: {{ .Values.sizing.nats.count | quote }}
+          value: {{ if and .Values.config.HA (eq (int .Values.sizing.nats.count) 1) }}{{ 2 | quote }}{{ else }}{{ .Values.sizing.nats.count | quote }}{{ end }}
```