### PR TITLE
Implement imagename option for config variables

### DIFF
--- a/model/variables.go
+++ b/model/variables.go
@@ -15,12 +15,8 @@ type Variables []*VariableDefinition
 type VariableDefinition struct {
 	Name      string
 	Type      string
-	Options   VariableOptions
 	CVOptions CVOptions
 }
-
-// VariableOptions are not structured, their content depends on the type
-type VariableOptions map[string]interface{}
 
 // CVOptions is a configuration to be exposed to the IaaS
 //

--- a/model/variables.go
+++ b/model/variables.go
@@ -44,6 +44,7 @@ type CVOptions struct {
 	Secret        bool        `yaml:"secret,omitempty"`
 	Required      bool        `yaml:"required,omitempty"`
 	Immutable     bool        `yaml:"immutable,omitempty"`
+	ImageName     bool        `yaml:"imagename,omitempty"`
 }
 
 // CVType is the type of the configuration variable; see the constants below


### PR DESCRIPTION
If the actual value of an imagename config variable doesn't include at least 2 slashes then it will be prefixed with `.kube.registry.hostname` and `.kube.organization`.