### PR TITLE
Fix logic for imagenames containing just an org without a registry

### DIFF
--- a/kube/pod.go
+++ b/kube/pod.go
@@ -514,10 +514,10 @@ func getEnvVarsFromConfigs(configs model.Variables, settings ExportSettings) (he
 			}
 			name := ".Values.env." + config.Name
 			if config.CVOptions.ImageName {
-				// Imagenames including 2 slashes already include the registry name and org.
+				// Imagenames including a slash already include at least an org name.
 				// All others will be prefixed with the registry and org from values.yaml.
 				kube := ".Values.kube"
-				tmpl := `{{if regexMatch "/.+/" %s}}{{%s | quote}}{{else}}` +
+				tmpl := `{{if contains "/" %s}}{{%s | quote}}{{else}}` +
 					`{{print %s.registry.hostname "/" %s.organization "/" %s | quote}}{{end}}`
 				stringifiedValue = fmt.Sprintf(tmpl, name, name, kube, kube, name)
 			} else {

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -1158,7 +1158,7 @@ func TestPodGetEnvVarsFromConfigNonSecretHelmImagename(t *testing.T) {
 		return
 	}
 
-	t.Run("WithRegistry", func(t *testing.T) {
+	t.Run("WithoutOrg", func(t *testing.T) {
 		t.Parallel()
 		config := map[string]interface{}{
 			"Values.kube.organization": "my-org",
@@ -1183,11 +1183,11 @@ func TestPodGetEnvVarsFromConfigNonSecretHelmImagename(t *testing.T) {
 		`, actual)
 	})
 
-	t.Run("WithoutRegistry", func(t *testing.T) {
+	t.Run("WithOrg", func(t *testing.T) {
 		t.Parallel()
 		config := map[string]interface{}{
 			"Values.kube.organization": "my-org",
-			"Values.env.IMAGENAME":     "registry/library/image:tag",
+			"Values.env.IMAGENAME":     "org/image:tag",
 		}
 
 		actual, err := RoundtripNode(ev, config)
@@ -1197,7 +1197,7 @@ func TestPodGetEnvVarsFromConfigNonSecretHelmImagename(t *testing.T) {
 
 		testhelpers.IsYAMLEqualString(assert, `---
 			-	name: "IMAGENAME"
-				value: "registry/library/image:tag"
+				value: "org/image:tag"
 			-	name: "KUBERNETES_NAMESPACE"
 				valueFrom:
 					fieldRef:


### PR DESCRIPTION
It makes no sense to prefix them with the registry and org from `values.yaml` because the result would have 2 org names. Also there is no good reason to require a docker.io registry prefix for all image names with an explicit org.