### PR TITLE
Add directories from BOSH agent to release image

### DIFF
--- a/scripts/dockerfiles/Dockerfile-release
+++ b/scripts/dockerfiles/Dockerfile-release
@@ -4,6 +4,18 @@ FROM {{ index . "base_image" }}
 LABEL "{{$label}}"="{{$value}}"
 {{ end }}
 
+RUN mkdir -p \
+	/var/vcap/data/blobs \
+	/var/vcap/data/compile \
+	/var/vcap/data/jobs \
+	/var/vcap/data/packages \
+	/var/vcap/data/sensitive_blobs \
+	/var/vcap/data/tmp \
+	/var/vcap/jobs \
+	/var/vcap/store \
+	/var/vcap/store_migration_target \
+	/var/vcap/sys/log
+
 ENV RELEASE_NAME {{ .name }}
 ENV RELEASE_VERSION {{ .version }}
 


### PR DESCRIPTION
Releases rely on some pre-existing directories:
https://github.com/cloudfoundry/bosh-agent/blob/2.1.x/settings/directories/directories_provider.go

[#166206072](https://www.pivotaltracker.com/story/show/166206072)