### PR TITLE
CAP-106 Skip validation of templated service account names

### DIFF
--- a/kube/rbac.go
+++ b/kube/rbac.go
@@ -36,9 +36,9 @@ func NewRBACAccount(accountName string, config *model.Configuration, settings Ex
 		return nil, nil
 	}
 
-	// If we want to modify the default account, there's no need to create it
-	// first -- it already exists
-	if accountName != "default" {
+	// If we want to modify the default account, there's no need to create it first -- it already exists.
+	// We also don't create templated account names; any possible name must already be defined elsewhere.
+	if accountName != "default" && !(strings.HasPrefix(accountName, "{{") && strings.HasSuffix(accountName, "}}")) {
 		var instanceGroupNames []string
 		for instanceGroupName := range account.UsedBy {
 			instanceGroupNames = append(instanceGroupNames, fmt.Sprintf("- %s", instanceGroupName))

--- a/model/resolver/resolver_test.go
+++ b/model/resolver/resolver_test.go
@@ -298,6 +298,24 @@ func TestLoadRoleManifestMissingRBACAccount(t *testing.T) {
 	assert.Nil(t, roleManifest)
 }
 
+func TestLoadRoleManifestTemplatedRBACAccount(t *testing.T) {
+	workDir, err := os.Getwd()
+	assert.NoError(t, err)
+
+	torReleasePath := filepath.Join(workDir, "../../test-assets/tor-boshrelease")
+	roleManifestPath := filepath.Join(workDir, "../../test-assets/role-manifests/model/rbac-templated-account.yml")
+	roleManifest, err := loader.LoadRoleManifest(roleManifestPath, model.LoadRoleManifestOptions{
+		ReleaseOptions: model.ReleaseOptions{
+			ReleasePaths:     []string{torReleasePath},
+			BOSHCacheDir:     filepath.Join(workDir, "../../test-assets/bosh-cache"),
+			FinalReleasesDir: filepath.Join(workDir, "../../test-assets/.final_releases")},
+		ValidationOptions: model.RoleManifestValidationOptions{
+			AllowMissingScripts: true,
+		}})
+	assert.NoError(t, err)
+	assert.NotNil(t, roleManifest)
+}
+
 func TestLoadRoleManifestMissingRBACRole(t *testing.T) {
 	workDir, err := os.Getwd()
 	assert.NoError(t, err)

--- a/model/resolver/validation_role_run.go
+++ b/model/resolver/validation_role_run.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"code.cloudfoundry.org/fissile/model"
 	"code.cloudfoundry.org/fissile/validation"
@@ -22,9 +23,11 @@ func validateRoleRun(instanceGroup *model.InstanceGroup, roleManifest *model.Rol
 
 	if instanceGroup.Run.ServiceAccount != "" {
 		accountName := instanceGroup.Run.ServiceAccount
-		if _, ok := roleManifest.Configuration.Authorization.Accounts[accountName]; !ok {
-			allErrs = append(allErrs, validation.NotFound(
-				fmt.Sprintf("instance_groups[%s].run.service-account", instanceGroup.Name), accountName))
+		if !(strings.HasPrefix(accountName, "{{") && strings.HasSuffix(accountName, "}}")) {
+			if _, ok := roleManifest.Configuration.Authorization.Accounts[accountName]; !ok {
+				allErrs = append(allErrs, validation.NotFound(
+					fmt.Sprintf("instance_groups[%s].run.service-account", instanceGroup.Name), accountName))
+			}
 		}
 	} else {
 		// Make the default ("default" (sic!)) explicit.

--- a/test-assets/role-manifests/model/rbac-templated-account.yml
+++ b/test-assets/role-manifests/model/rbac-templated-account.yml
@@ -1,0 +1,10 @@
+---
+instance_groups:
+- name: myrole
+  jobs:
+  - name: new_hostname
+    release: tor
+    properties:
+      bosh_containerization:
+        run:
+          service-account: '{{if .Values.enable.feature}}feature{{else}}default{{end}}'


### PR DESCRIPTION
This allows the user to "tunnel through" a template expression to select the service account at deployment time based on the enabled features, e.g.

```
service-account: '{{if .Values.enable.feature}}feature{{else}}default{{end}}'
```

Any service account name generated by the template expression must also be used by at least one role in the chart unconditionally because will will not emit definitions for service account that are not used by the chart at all (normally only the service accounts for the tests).
