### PR TITLE
Allow sizing.XXX.count under config.HA=true to be set to the default SA value

### DIFF
--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -424,7 +424,7 @@ func TestPodGetEnvVarsFromConfigSizingCountHelm(t *testing.T) {
 	`, actual)
 
 	config = map[string]interface{}{
-		"Values.sizing.foo.count": 1, // Run.Scaling.Min
+		"Values.sizing.foo.count": nil,
 		"Values.config.HA":        true,
 	}
 
@@ -444,6 +444,29 @@ func TestPodGetEnvVarsFromConfigSizingCountHelm(t *testing.T) {
 		-	name: "VCAP_SOFT_NPROC"
 			value: "1024"
 	`, actual)
+
+	config = map[string]interface{}{
+		"Values.sizing.foo.count": 2,
+		"Values.config.HA":        true,
+	}
+
+	actual, err = RoundtripNode(ev, config)
+	if !assert.NoError(err) {
+		return
+	}
+	testhelpers.IsYAMLEqualString(assert, `---
+		-	name: "KUBERNETES_NAMESPACE"
+			valueFrom:
+				fieldRef:
+					fieldPath: "metadata.namespace"
+		-	name: "KUBE_SIZING_FOO_COUNT"
+			value: "2"
+		-	name: "VCAP_HARD_NPROC"
+			value: "2048"
+		-	name: "VCAP_SOFT_NPROC"
+			value: "1024"
+	`, actual)
+
 }
 
 func TestPodGetEnvVarsFromConfigSizingPortsKube(t *testing.T) {

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -201,6 +201,7 @@ func MakeBasicValues() *helm.Mapping {
 		),
 		"config", helm.NewMapping(
 			"HA", helm.NewNode(false, helm.Comment("Flag to activate high-availability mode")),
+			"HA_strict", helm.NewNode(true, helm.Comment("Flag to verify instance counts against HA minimums")),
 			"memory", helm.NewNode(helm.NewMapping(
 				"requests", helm.NewNode(false, helm.Comment("Flag to activate memory requests")),
 				"limits", helm.NewNode(false, helm.Comment("Flag to activate memory limits")),

--- a/kube/values.go
+++ b/kube/values.go
@@ -122,7 +122,7 @@ func MakeValues(settings ExportSettings) helm.Node {
 					instanceGroup.Run.Scaling.HA)
 			}
 		}
-		entry.Add("count", instanceGroup.Run.Scaling.Min, helm.Comment(comment))
+		entry.Add("count", nil, helm.Comment(comment))
 		if settings.UseMemoryLimits {
 			var request helm.Node
 			if instanceGroup.Run.Memory.Request == nil {

--- a/test-assets/role-manifests/kube/pod-with-valid-pod-anti-affinity.yml
+++ b/test-assets/role-manifests/kube/pod-with-valid-pod-anti-affinity.yml
@@ -10,7 +10,8 @@ instance_groups:
           memory: 128
           scaling:
             min: 1
-            max: 1
+            ha: 2
+            max: 3
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
This changes all counts in `values.yaml` to `nil` instead of the default SA (min) value. That way the template can differentiate between the count being set by the user vs. still having the default value from `values.yaml`.

The templates will still throw an error when `config.HA` is true and the `count` for a role is set to less than the `ha` minimum. If that is intended, then the new `config.HA_strict` variable must be set to `false`.

```
--set config.HA=true --set config.HA_strict=false --set sizing.FOO.count=1
```