### PR TITLE
Use a better check to see if a template variable is nil

### DIFF
--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -141,7 +141,7 @@ func generalCheck(instanceGroup *model.InstanceGroup, controller *helm.Mapping, 
 }
 
 func notNil(variable string) string {
-	return fmt.Sprintf(`(not (eq (quote %s) "\"<nil>\""))`, variable)
+	return fmt.Sprintf(`(ne (typeOf %s) "<nil>")`, variable)
 }
 
 func replicaCount(instanceGroup *model.InstanceGroup, quoted bool) string {


### PR DESCRIPTION
The `(quote nil)` value changed in tiller between 2.11.0 and 2.14.0 from `"<nil>"` to the empty string, while `(typeOf nil)` continues to render as `<nil>`.

[jsc#CAP-593]