### PR TITLE
Adding a new flag in fissile build

### DIFF
--- a/builder/release_image.go
+++ b/builder/release_image.go
@@ -30,10 +30,10 @@ import (
 type ReleasesImageBuilder struct {
 	CompilationCacheConfig string
 	CompilationDir         string
-	DisplayImageName       bool
 	DockerNetworkMode      string
 	DockerOrganization     string
 	DockerRegistry         string
+	DryRun                 bool
 	FissileVersion         string
 	Force                  bool
 	Grapher                util.ModelGrapher
@@ -277,8 +277,9 @@ func (j releaseBuildJob) Run() {
 			return err
 		}
 
-		if r.DisplayImageName {
-			r.UI.Printf("Image Name: %s\n", color.YellowString(imageName))
+		r.UI.Printf("Image Name: %s\n", color.YellowString(imageName))
+
+		if r.DryRun {
 			return nil
 		}
 

--- a/builder/release_image.go
+++ b/builder/release_image.go
@@ -30,6 +30,7 @@ import (
 type ReleasesImageBuilder struct {
 	CompilationCacheConfig string
 	CompilationDir         string
+	DisplayImageName       bool
 	DockerNetworkMode      string
 	DockerOrganization     string
 	DockerRegistry         string
@@ -40,7 +41,6 @@ type ReleasesImageBuilder struct {
 	NoBuild                bool
 	OutputDirectory        string
 	RepositoryPrefix       string
-	ShowImageName          bool
 	StemcellName           string
 	StreamPackages         bool
 	UI                     *termui.UI
@@ -277,7 +277,7 @@ func (j releaseBuildJob) Run() {
 			return err
 		}
 
-		if r.ShowImageName {
+		if r.DisplayImageName {
 			r.UI.Printf("Image Name: %s\n", color.YellowString(imageName))
 			return nil
 		}

--- a/builder/release_image.go
+++ b/builder/release_image.go
@@ -40,6 +40,7 @@ type ReleasesImageBuilder struct {
 	NoBuild                bool
 	OutputDirectory        string
 	RepositoryPrefix       string
+	ShowImageName          bool
 	StemcellName           string
 	StreamPackages         bool
 	UI                     *termui.UI
@@ -275,6 +276,12 @@ func (j releaseBuildJob) Run() {
 		if err != nil {
 			return err
 		}
+
+		if r.ShowImageName {
+			r.UI.Printf("Image Name: %s\n", color.YellowString(imageName))
+			return nil
+		}
+
 		outputPath := fmt.Sprintf("%s.tar", imageName)
 
 		if r.OutputDirectory != "" {

--- a/cmd/build-release-images.go
+++ b/cmd/build-release-images.go
@@ -33,6 +33,7 @@ This command goes through builds a Docker image for each specified release.
 			NoBuild:                buildReleaseImagesViper.GetBool("no-build"),
 			OutputDirectory:        buildReleaseImagesViper.GetString("output-directory"),
 			RepositoryPrefix:       fissile.Options.RepositoryPrefix,
+			ShowImageName:          buildReleaseImagesViper.GetBool("show-image-name"),
 			StemcellName:           buildReleaseImagesViper.GetString("stemcell"),
 			StreamPackages:         buildPackagesViper.GetBool("stream-packages"),
 			UI:                     fissile.UI,
@@ -187,6 +188,13 @@ func init() {
 		"",
 		false,
 		"If true, fissile will stream packages to the docker daemon for compilation, instead of mounting volumes",
+	)
+
+	buildReleaseImagesCmd.PersistentFlags().BoolP(
+		"show-image-name",
+		"",
+		false,
+		"If true, displays the name of the image to be built without actually building it",
 	)
 
 	buildReleaseImagesViper.BindPFlags(buildReleaseImagesCmd.PersistentFlags())

--- a/cmd/build-release-images.go
+++ b/cmd/build-release-images.go
@@ -23,10 +23,10 @@ This command goes through builds a Docker image for each specified release.
 	RunE: func(cmd *cobra.Command, args []string) error {
 		imgBuilder := &builder.ReleasesImageBuilder{
 			CompilationCacheConfig: buildReleaseImagesViper.GetString("compilation-cache-config"),
-			DisplayImageName:       buildReleaseImagesViper.GetBool("display-image-name"),
 			DockerNetworkMode:      buildPackagesViper.GetString("docker-network-mode"),
 			DockerOrganization:     fissile.Options.DockerOrganization,
 			DockerRegistry:         fissile.Options.DockerRegistry,
+			DryRun:                 buildReleaseImagesViper.GetBool("dry-run"),
 			FissileVersion:         fissile.Version,
 			Force:                  buildReleaseImagesViper.GetBool("force"),
 			Grapher:                fissile,
@@ -191,10 +191,10 @@ func init() {
 	)
 
 	buildReleaseImagesCmd.PersistentFlags().BoolP(
-		"display-image-name",
+		"dry-run",
 		"",
 		false,
-		"If true, displays the name of the image to be built without actually building it",
+		"If true, invokes a dry run i.e. skips building the images",
 	)
 
 	buildReleaseImagesViper.BindPFlags(buildReleaseImagesCmd.PersistentFlags())

--- a/cmd/build-release-images.go
+++ b/cmd/build-release-images.go
@@ -23,6 +23,7 @@ This command goes through builds a Docker image for each specified release.
 	RunE: func(cmd *cobra.Command, args []string) error {
 		imgBuilder := &builder.ReleasesImageBuilder{
 			CompilationCacheConfig: buildReleaseImagesViper.GetString("compilation-cache-config"),
+			DisplayImageName:       buildReleaseImagesViper.GetBool("display-image-name"),
 			DockerNetworkMode:      buildPackagesViper.GetString("docker-network-mode"),
 			DockerOrganization:     fissile.Options.DockerOrganization,
 			DockerRegistry:         fissile.Options.DockerRegistry,
@@ -33,7 +34,6 @@ This command goes through builds a Docker image for each specified release.
 			NoBuild:                buildReleaseImagesViper.GetBool("no-build"),
 			OutputDirectory:        buildReleaseImagesViper.GetString("output-directory"),
 			RepositoryPrefix:       fissile.Options.RepositoryPrefix,
-			ShowImageName:          buildReleaseImagesViper.GetBool("show-image-name"),
 			StemcellName:           buildReleaseImagesViper.GetString("stemcell"),
 			StreamPackages:         buildPackagesViper.GetBool("stream-packages"),
 			UI:                     fissile.UI,
@@ -191,7 +191,7 @@ func init() {
 	)
 
 	buildReleaseImagesCmd.PersistentFlags().BoolP(
-		"show-image-name",
+		"display-image-name",
 		"",
 		false,
 		"If true, displays the name of the image to be built without actually building it",


### PR DESCRIPTION
## Description

This PR is to introduce:

1. Printing the name of the image to be built.
2. `--dry-run` flag to skip image build step.

## Test plan

Trigger `fissile build` with `--dry-run` and check whether the build part was skipped, also confirm whether image name was displayed.