### PR TITLE
Extend feature-flag support to job objects

### DIFF
--- a/kube/job.go
+++ b/kube/job.go
@@ -41,6 +41,7 @@ func NewJob(instanceGroup *model.InstanceGroup, settings ExportSettings, grapher
 		return nil, fmt.Errorf("failed to build a new kube config: %v", err)
 	}
 	job.Add("spec", helm.NewMapping("template", podTemplate))
+	addFeatureCheck(instanceGroup, job)
 
 	return job.Sort(), nil
 }

--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -58,7 +58,8 @@ func NewStatefulSet(role *model.InstanceGroup, settings ExportSettings, grapher 
 		return nil, nil, fmt.Errorf("failed to build a new kube config: %v", err)
 	}
 	statefulSet.Add("spec", spec)
-	err = replicaCheck(role, statefulSet, svcList, settings)
+	addFeatureCheck(role, statefulSet, svcList)
+	err = replicaCheck(role, statefulSet, settings)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Previously only deployments and stateful sets could be enabled or disabled by feature flags.

[jsc#CAP-628]