### PR TITLE
kube: Bump resource versions to what kube 1.16 wants

### DIFF
--- a/app/fissile_test.go
+++ b/app/fissile_test.go
@@ -506,7 +506,7 @@ func TestGenerateAuth(t *testing.T) {
 		},
 		`auth/auth-psp-nonprivileged.yaml`: []string{
 			`{
-				"apiVersion": "extensions/v1beta1",
+				"apiVersion": "policy/v1beta1",
 				"kind": "PodSecurityPolicy",
 				"metadata": {
 					"name": "nonprivileged",

--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -26,7 +26,7 @@ func NewDeployment(instanceGroup *model.InstanceGroup, settings ExportSettings, 
 
 	cb := NewConfigBuilder().
 		SetSettings(&settings).
-		SetAPIVersion("extensions/v1beta1").
+		SetConditionalAPIVersion("apps/v1", "extensions/v1beta1").
 		SetKind("Deployment").
 		SetName(instanceGroup.Name).
 		AddModifier(helm.Comment(instanceGroup.GetLongDescription()))

--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -220,7 +220,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 			return
 		}
 		testhelpers.IsYAMLEqualString(assert, `---
-			apiVersion: "extensions/v1beta1"
+			apiVersion: "apps/v1"
 			kind: "Deployment"
 			metadata:
 				name: "some-group"
@@ -355,7 +355,7 @@ func TestNewDeploymentIstioManagedHelm(t *testing.T) {
 			return
 		}
 		testhelpers.IsYAMLEqualString(assert, `---
-			apiVersion: "extensions/v1beta1"
+			apiVersion: "apps/v1"
 			kind: "Deployment"
 			metadata:
 				name: "istio-managed-group"
@@ -632,7 +632,7 @@ func TestNewDeploymentWithEmptyDirVolume(t *testing.T) {
 			return
 		}
 		testhelpers.IsYAMLSubsetString(assert, `---
-			apiVersion: "extensions/v1beta1"
+			apiVersion: "apps/v1"
 			kind: "Deployment"
 			spec:
 				template:

--- a/kube/kube_test.go
+++ b/kube/kube_test.go
@@ -44,7 +44,10 @@ func RenderNode(node helm.Node, config interface{}) ([]byte, error) {
 				"Minor": "8",
 			},
 			"APIVersions": &fakeAPIVersions{
+				"apps/v1":                      true,
 				"rbac.authorization.k8s.io/v1": true,
+				"networking.k8s.io/v1":         true,
+				"policy/v1beta1":               true,
 			},
 		},
 		"Template": map[string]interface{}{

--- a/kube/rbac.go
+++ b/kube/rbac.go
@@ -222,7 +222,7 @@ func NewRBACRole(name string, kind RBACRoleKind, authRole model.AuthRole, settin
 func NewRBACPSP(name string, psp *model.PodSecurityPolicy, settings ExportSettings) (helm.Node, error) {
 	cb := NewConfigBuilder().
 		SetSettings(&settings).
-		SetAPIVersion("extensions/v1beta1").
+		SetConditionalAPIVersion("policy/v1beta1", "extensions/v1beta1").
 		SetKind("PodSecurityPolicy").
 		AddModifier(helm.Comment(fmt.Sprintf(`Pod security policy "%s"`, name)))
 	if settings.CreateHelmChart {

--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -49,7 +49,7 @@ func NewStatefulSet(role *model.InstanceGroup, settings ExportSettings, grapher 
 
 	cb := NewConfigBuilder().
 		SetSettings(&settings).
-		SetAPIVersion("apps/v1beta1").
+		SetConditionalAPIVersion("apps/v1", "apps/v1beta1").
 		SetKind("StatefulSet").
 		SetName(role.Name).
 		AddModifier(helm.Comment(role.GetLongDescription()))

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -75,6 +75,23 @@ func (b *ConfigBuilder) SetAPIVersion(apiVersion string) *ConfigBuilder {
 	return b
 }
 
+// SetConditionalAPIVersion sets the kube API version of the resource to build;
+// if that API version is not available, use a fallback instead (to be
+// compatible with older releases of kube).  If we are not building a helm
+// chart, the desired API version is always used.
+func (b *ConfigBuilder) SetConditionalAPIVersion(apiVersion, fallbackAPIVersion string) *ConfigBuilder {
+	if b.settings == nil || !b.settings.CreateHelmChart {
+		b.apiVersion = apiVersion
+	} else {
+		b.apiVersion = fmt.Sprintf(
+			`{{ ternary "%s" "%s" (.Capabilities.APIVersions.Has "%s") }}`,
+			apiVersion,
+			fallbackAPIVersion,
+			apiVersion)
+	}
+	return b
+}
+
 // SetKind sets the kubernetes resource kind of the resource to build.
 func (b *ConfigBuilder) SetKind(kind string) *ConfigBuilder {
 	b.kind = kind

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -84,10 +84,10 @@ func (b *ConfigBuilder) SetConditionalAPIVersion(apiVersion, fallbackAPIVersion 
 		b.apiVersion = apiVersion
 	} else {
 		b.apiVersion = fmt.Sprintf(
-			`{{ ternary "%s" "%s" (.Capabilities.APIVersions.Has "%s") }}`,
+			`{{ if (.Capabilities.APIVersions.Has "%s") }}%s{{ else }}%s{{ end }}`,
 			apiVersion,
-			fallbackAPIVersion,
-			apiVersion)
+			apiVersion,
+			fallbackAPIVersion)
 	}
 	return b
 }


### PR DESCRIPTION
- `extensions`/`v1beta1/Deployment` moved to `apps/v1`
- `extensions/v1beta1`/`PodSecurityPolicy` moved to `policy/v1beta1`
- `apps/v1beta1`/`StatefulSet` moved to `apps/v1`
- Add support for fallback versions (to run on older kubes), even though we probably no longer support those obsolete kube clusters.

Fixes #514