### PR TITLE
Set default probe timeout to 10s and default period to 30s

### DIFF
--- a/kube/pod.go
+++ b/kube/pod.go
@@ -628,6 +628,12 @@ func getContainerReadinessProbe(role *model.InstanceGroup) (helm.Node, error) {
 					probe.Add(name, value)
 				}
 			}
+			if roleProbe.Timeout == 0 {
+				roleProbe.Timeout = 10
+			}
+			if roleProbe.Period == 0 {
+				roleProbe.Period = 30
+			}
 			addParam("initialDelaySeconds", roleProbe.InitialDelay)
 			addParam("timeoutSeconds", roleProbe.Timeout)
 			addParam("periodSeconds", roleProbe.Period)

--- a/scripts/dockerfiles/readiness-probe.sh
+++ b/scripts/dockerfiles/readiness-probe.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# Log duration of readiness probes.
+START="$(date +%s)"
+trap runtime EXIT
+runtime () {
+    STOP="$(date +%s)"
+    echo "TxPROBE,${KUBERNETES_NAMESPACE},${HOSTNAME},${START},${STOP},$(expr $STOP - $START)" >> rp-duration-stats.csv
+    return $?
+}
+
 # This is the default readiness probe, which will look at all monit monitored
 # processes and check that they are ready.
 
@@ -35,6 +44,7 @@ update_readiness() {
                 }
             }
         }'
+    runtime
     return $?
 }
 if test -n "${FISSILE_ACTIVE_PASSIVE_PROBE:-}" ; then


### PR DESCRIPTION
Experimental change to help debugging CAP on CaaSP 4.

This PR will be deleted once the experiment is done; it should never be merged!

[jsc#CAP-766]