### PR TITLE
Add KUBERNETES_CONTAINER_NAME env var

### DIFF
--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -273,6 +273,8 @@ func TestNewDeploymentHelm(t *testing.T) {
 						-	env:
 							-	name: "KUBERNETES_CLUSTER_DOMAIN"
 								value: "cluster.local"
+							-	name: "KUBERNETES_CONTAINER_NAME"
+								value: "some-group"
 							-	name: "KUBERNETES_NAMESPACE"
 								valueFrom:
 									fieldRef:
@@ -409,6 +411,8 @@ func TestNewDeploymentIstioManagedHelm(t *testing.T) {
 						-	env:
 							-	name: "KUBERNETES_CLUSTER_DOMAIN"
 								value: "cluster.local"
+							-	name: "KUBERNETES_CONTAINER_NAME"
+								value: "istio-managed-group"
 							-	name: "KUBERNETES_NAMESPACE"
 								valueFrom:
 									fieldRef:

--- a/kube/job_test.go
+++ b/kube/job_test.go
@@ -191,6 +191,8 @@ func TestJobHelm(t *testing.T) {
 					-	env:
 						-	name: "KUBERNETES_CLUSTER_DOMAIN"
 							value: "cluster.local"
+						-	name: "KUBERNETES_CONTAINER_NAME"
+							value: "pre-role"
 						-	name: "KUBERNETES_NAMESPACE"
 							valueFrom:
 								fieldRef:

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -1953,6 +1953,8 @@ func TestPodPreFlightHelm(t *testing.T) {
 			-	env:
 				-	name: "KUBERNETES_CLUSTER_DOMAIN"
 					value: "cluster.local"
+				-	name: "KUBERNETES_CONTAINER_NAME"
+					value: "pre-role"
 				-	name: "KUBERNETES_NAMESPACE"
 					valueFrom:
 						fieldRef:
@@ -2073,6 +2075,8 @@ func TestPodPostFlightHelm(t *testing.T) {
 			-	env:
 				-	name: "KUBERNETES_CLUSTER_DOMAIN"
 					value: "cluster.local"
+				-	name: "KUBERNETES_CONTAINER_NAME"
+					value: "post-role"
 				-	name: "KUBERNETES_NAMESPACE"
 					valueFrom:
 						fieldRef:
@@ -2203,6 +2207,8 @@ func TestPodMemoryHelmDisabled(t *testing.T) {
 			-	env:
 				-	name: "KUBERNETES_CLUSTER_DOMAIN"
 					value: "cluster.local"
+				-	name: "KUBERNETES_CONTAINER_NAME"
+					value: "pre-role"
 				-	name: "KUBERNETES_NAMESPACE"
 					valueFrom:
 						fieldRef:
@@ -2296,6 +2302,8 @@ func TestPodMemoryHelmActive(t *testing.T) {
 			-	env:
 				-	name: "KUBERNETES_CLUSTER_DOMAIN"
 					value: "cluster.local"
+				-	name: "KUBERNETES_CONTAINER_NAME"
+					value: "pre-role"
 				-	name: "KUBERNETES_NAMESPACE"
 					valueFrom:
 						fieldRef:
@@ -2428,6 +2436,8 @@ func TestPodCPUHelmDisabled(t *testing.T) {
 			-	env:
 				-	name: "KUBERNETES_CLUSTER_DOMAIN"
 					value: "cluster.local"
+				-	name: "KUBERNETES_CONTAINER_NAME"
+					value: "pre-role"
 				-	name: "KUBERNETES_NAMESPACE"
 					valueFrom:
 						fieldRef:
@@ -2521,6 +2531,8 @@ func TestPodCPUHelmActive(t *testing.T) {
 			-	env:
 				-	name: "KUBERNETES_CLUSTER_DOMAIN"
 					value: "cluster.local"
+				-	name: "KUBERNETES_CONTAINER_NAME"
+					value: "pre-role"
 				-	name: "KUBERNETES_NAMESPACE"
 					valueFrom:
 						fieldRef:
@@ -2969,6 +2981,8 @@ func TestPodIstioManagedHelm(t *testing.T) {
 			-	env:
 				-	name: "KUBERNETES_CLUSTER_DOMAIN"
 					value: "cluster.local"
+				-	name: "KUBERNETES_CONTAINER_NAME"
+					value: "istio-managed-role"
 				-	name: "KUBERNETES_NAMESPACE"
 					valueFrom:
 						fieldRef:

--- a/model/mustache.go
+++ b/model/mustache.go
@@ -78,6 +78,14 @@ func (g *InstanceGroup) GetVariablesForRole() (Variables, error) {
 		}
 	}
 
+	configs["KUBERNETES_CONTAINER_NAME"] = &VariableDefinition{
+		Name: "KUBERNETES_CONTAINER_NAME",
+		CVOptions: CVOptions{
+			Type:    CVTypeEnv,
+			Default: g.Name,
+		},
+	}
+
 	result := make(Variables, 0, len(configs))
 
 	for _, value := range configs {

--- a/model/mustache.go
+++ b/model/mustache.go
@@ -81,7 +81,10 @@ func (g *InstanceGroup) GetVariablesForRole() (Variables, error) {
 	configs["KUBERNETES_CONTAINER_NAME"] = &VariableDefinition{
 		Name: "KUBERNETES_CONTAINER_NAME",
 		CVOptions: CVOptions{
-			Type:    CVTypeEnv,
+			Type: CVTypeEnv,
+			// The name of the statefulset is derived from the instance group name of
+			// the main container. Co-located containers have their own, independent
+			// (and non-unique) instance group names, e.g. `loggregator-agent`.
 			Default: g.Name,
 		},
 	}

--- a/model/resolver/validation_test.go
+++ b/model/resolver/validation_test.go
@@ -58,7 +58,7 @@ func TestRoleVariables(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, vars)
 
-	expected := []string{"HOME", "FOO", "BAR", "KUBERNETES_CLUSTER_DOMAIN", "PELERINUL"}
+	expected := []string{"HOME", "FOO", "BAR", "KUBERNETES_CLUSTER_DOMAIN", "KUBERNETES_CONTAINER_NAME", "PELERINUL"}
 	sort.Strings(expected)
 	var actual []string
 	for _, variable := range vars {


### PR DESCRIPTION
This is needed by configgin to export properties only from the container whose name matches the role name (and not the loggregator agent sidecar). There seems to be no mechanism to reference the `container.name` field in the env section, so the value has to be provided by fissile.

[jsc#CAP-761]