### PR TITLE
Pod startup ordering

### DIFF
--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -271,6 +271,8 @@ func TestNewDeploymentHelm(t *testing.T) {
 							nodeAffinity: "snafu"
 						containers:
 						-	env:
+							-	name: CONFIGGIN_VERSION_TAG
+								value: 42.1+foo-1
 							-	name: "KUBERNETES_CLUSTER_DOMAIN"
 								value: "cluster.local"
 							-	name: "KUBERNETES_CONTAINER_NAME"
@@ -409,6 +411,8 @@ func TestNewDeploymentIstioManagedHelm(t *testing.T) {
 							nodeAffinity: "snafu"
 						containers:
 						-	env:
+							-	name: CONFIGGIN_VERSION_TAG
+								value: 42.1+foo-1
 							-	name: "KUBERNETES_CLUSTER_DOMAIN"
 								value: "cluster.local"
 							-	name: "KUBERNETES_CONTAINER_NAME"

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -363,7 +363,7 @@ func getEnvVars(role *model.InstanceGroup, settings ExportSettings) (helm.Node, 
 		return nil, err
 	}
 
-	if settings.CreateHelmChart && role.Type == model.RoleTypeBosh {
+	if settings.CreateHelmChart && (role.Type == model.RoleTypeBosh || role.Type == model.RoleTypeColocatedContainer) {
 		env = append(env, helm.NewMapping("name", "CONFIGGIN_VERSION_TAG", "value", versionSuffix))
 
 		// Waiting for our own secret to be created would be a deadlock.

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -303,7 +303,8 @@ func getVolumeMounts(role *model.InstanceGroup, settings ExportSettings) helm.No
 }
 
 const userSecretsName = "secrets"
-const generatedSecretsName = "secrets-{{ .Chart.Version }}-{{ .Values.kube.secrets_generation_counter }}"
+const versionSuffix = "{{ .Chart.Version }}-{{ .Values.kube.secrets_generation_counter }}"
+const generatedSecretsName = "secrets-" + versionSuffix
 
 func makeSecretVar(name string, generated bool, modifiers ...helm.NodeModifier) helm.Node {
 	secretKeyRef := helm.NewMapping("key", util.ConvertNameToKey(name))
@@ -357,10 +358,48 @@ func getEnvVars(role *model.InstanceGroup, settings ExportSettings) (helm.Node, 
 		return nil, err
 	}
 
-	return getEnvVarsFromConfigs(configs, settings)
+	env, err := getEnvVarsFromConfigs(configs, settings)
+	if err != nil {
+		return nil, err
+	}
+
+	if settings.CreateHelmChart && role.Type == model.RoleTypeBosh {
+		env = append(env, helm.NewMapping("name", "CONFIGGIN_VERSION_TAG", "value", versionSuffix))
+
+		// Waiting for our own secret to be created would be a deadlock.
+		seen := map[string]bool{role.Name: true}
+		for _, job := range role.JobReferences {
+			for _, consumer := range job.ResolvedConsumes {
+				roleName := consumer.JobLinkInfo.RoleName
+				if seen[roleName] {
+					continue
+				}
+				seen[roleName] = true
+
+				// Create a link to each statefulset we want to import properties from.
+				// This makes sure our pods don't start until the secret is available.
+				// The environment variables are not actually used for anything else.
+				name := "CONFIGGIN_IMPORT_" + strings.ToUpper(makeVarName(roleName))
+				envVar := helm.NewMapping("name", name)
+				secretKeyRef := helm.NewMapping("name", roleName, "key", versionSuffix)
+				envVar.Add("valueFrom", helm.NewMapping("secretKeyRef", secretKeyRef))
+
+				// Make sure not to wait for roles that have been disabled, e.g. credhub
+				addFeatureCheck(settings.RoleManifest.LookupInstanceGroup(roleName), envVar)
+
+				env = append(env, envVar)
+			}
+		}
+	}
+
+	sort.Slice(env[:], func(i, j int) bool {
+		return env[i].Get("name").String() < env[j].Get("name").String()
+	})
+
+	return helm.NewNode(env), nil
 }
 
-func getEnvVarsFromConfigs(configs model.Variables, settings ExportSettings) (helm.Node, error) {
+func getEnvVarsFromConfigs(configs model.Variables, settings ExportSettings) ([]helm.Node, error) {
 	featureRexgexp := regexp.MustCompile("^FEATURE_([A-Z][A-Z_]*)_ENABLED$")
 	sizingCountRegexp := regexp.MustCompile("^KUBE_SIZING_([A-Z][A-Z_]*)_COUNT$")
 	sizingPortsRegexp := regexp.MustCompile("^KUBE_SIZING_([A-Z][A-Z_]*)_PORTS_([A-Z][A-Z_]*)_(MIN|MAX)$")
@@ -556,10 +595,11 @@ func getEnvVarsFromConfigs(configs model.Variables, settings ExportSettings) (he
 			"value", "1024"))
 	}
 
+	// sorting here purely for the benefit of the tests because the caller will sort again...
 	sort.Slice(env[:], func(i, j int) bool {
 		return env[i].Get("name").String() < env[j].Get("name").String()
 	})
-	return helm.NewNode(env), nil
+	return env, nil
 }
 
 func getSecurityContext(instanceGroup *model.InstanceGroup) helm.Node {

--- a/model/instance_groups.go
+++ b/model/instance_groups.go
@@ -78,6 +78,11 @@ func (g *InstanceGroup) SetRoleManifest(m *RoleManifest) {
 	g.roleManifest = m
 }
 
+// Manifest return a reference to the instance groups role manifest
+func (g *InstanceGroup) Manifest() *RoleManifest {
+	return g.roleManifest
+}
+
 // CalculateRoleRun collects properties from the jobs run properties and puts them on the instance group
 // It also validates where necessary and is run *before* validateRoleRun
 func (g *InstanceGroup) CalculateRoleRun() validation.ErrorList {

--- a/model/instance_groups.go
+++ b/model/instance_groups.go
@@ -78,7 +78,7 @@ func (g *InstanceGroup) SetRoleManifest(m *RoleManifest) {
 	g.roleManifest = m
 }
 
-// Manifest return a reference to the instance groups role manifest
+// Manifest returns a reference to the instance groups role manifest
 func (g *InstanceGroup) Manifest() *RoleManifest {
 	return g.roleManifest
 }

--- a/model/job.go
+++ b/model/job.go
@@ -36,6 +36,7 @@ type JobProvidesInfo struct {
 type JobConsumesInfo struct {
 	JobLinkInfo
 	Alias    string `yaml:"from"`
+	Ignore   bool   `yaml:"ignore"`
 	Optional bool
 }
 

--- a/model/resolver/resolver.go
+++ b/model/resolver/resolver.go
@@ -310,10 +310,13 @@ func (r *Resolver) ResolveLinks() validation.ErrorList {
 						fmt.Sprintf(`consumer %s not found`, consumerAlias)))
 					continue
 				}
-				jobReference.ResolvedConsumes[consumerName] = model.JobConsumesInfo{
-					JobLinkInfo: provider.JobLinkInfo,
+				if consumerInfo.Ignore {
+					delete(jobReference.ResolvedConsumes, consumerName)
+				} else {
+					jobReference.ResolvedConsumes[consumerName] = model.JobConsumesInfo{
+						JobLinkInfo: provider.JobLinkInfo,
+					}
 				}
-
 				for i := range expectedConsumers {
 					if expectedConsumers[i].Name == consumerName {
 						expectedConsumers = append(expectedConsumers[:i], expectedConsumers[i+1:]...)

--- a/model/resolver/resolver_test.go
+++ b/model/resolver/resolver_test.go
@@ -452,7 +452,7 @@ func TestResolveLinks(t *testing.T) {
 			Missing  bool
 		}{
 			// These should match the order in the ntp-release ntp job.MF
-			{Name: "ntp-server", Type: "ntpd"},
+			// ntp-server is missing because it is being explicitly ignored by the manifest
 			{Name: "ntp-client", Type: "ntp"},
 			{Type: "missing", Missing: true},
 		}
@@ -487,9 +487,7 @@ func TestResolveLinks(t *testing.T) {
 				{RoleName: "myrole", JobName: "ntpd"},
 				{RoleName: "foorole", JobName: "tor"},
 			},
-			"ntp-server": []model.JobLinkInfo{
-				{RoleName: "myrole", JobName: "ntpd"},
-			},
+			// ntp-server is explicitly ignored by the manifest
 		}
 		for linkName, expectedConsumedByList := range expected {
 			t.Run(linkName, func(t *testing.T) {

--- a/test-assets/role-manifests/kube/volumes.yml
+++ b/test-assets/role-manifests/kube/volumes.yml
@@ -24,8 +24,9 @@ instance_groups:
           - path: /sys/fs/cgroup
             type: host
             tag: host-volume
-# The provider role only exist so that TestPodGetEnvVarsConfiggin can use
-# it to reference in a mock up bosh link.
+# The provider role only exists for the benefit of TestPodGetEnvVarsConfiggin.
+# It creates a mock bosh link to `provider` in `myrole` at runtime to verify
+# that a CONFIGGIN_IMPORT_PROVIDER secret reference is created for it.
 - name: provider
   jobs:
   - name: tor

--- a/test-assets/role-manifests/kube/volumes.yml
+++ b/test-assets/role-manifests/kube/volumes.yml
@@ -24,6 +24,17 @@ instance_groups:
           - path: /sys/fs/cgroup
             type: host
             tag: host-volume
+# The provider role only exist so that TestPodGetEnvVarsConfiggin can use
+# it to reference in a mock up bosh link.
+- name: provider
+  jobs:
+  - name: tor
+    release: tor
+    properties:
+      bosh_containerization:
+        run:
+          scaling:
+            min: 1
 configuration:
   templates:
     fox: ((SOME_VAR))

--- a/test-assets/role-manifests/model/multiple-good.yml
+++ b/test-assets/role-manifests/model/multiple-good.yml
@@ -14,7 +14,9 @@ instance_groups:
   - name: ntpd
     release: ntp
     provides:
-      ntp-client: {}
+      ntp-server: {}
+    consumes:
+      ntp-server: {ignore: true}
 - name: foorole
   type: bosh-task
   jobs:


### PR DESCRIPTION
# Implement configgin startup synchronization

The next version of configgin will export bosh properties to a secret and tag it with the value of `CONFIGGIN_VERSION_TAG` (the helm chart version plus the secrets rotation count).

Fissile now defines an environment variable that references that role's secret tag in each role that needs to import links from it. This has the effect of delaying startup of the pod until all links that have to be imported have been written to their corresponding secrets.

# Implement `ignore` option for link consumers

In the rolemanifest a job can now explicitly state that a specified bosh link will *not* be consumed:

```
      jobs:
      - name: sample-job
        release: sample
        consumes:
          not-used: {ignore: true}
```

The link definition will not be included in the job information passed on to Configgin, so the link will not resolve at runtime. It is the responsibility of the templates to not reference it (by setting properties, or by patching the templates).

Note that this feature allows ignoring of non-optional links as well!
