### PR TITLE
Define CONFIGGIN_SA_TOKEN for all pods using configgin

### DIFF
--- a/kube/job_test.go
+++ b/kube/job_test.go
@@ -189,6 +189,11 @@ func TestJobHelm(t *testing.T) {
 				spec:
 					containers:
 					-	env:
+						-	name: CONFIGGIN_SA_TOKEN
+							valueFrom:
+								secretKeyRef:
+									key: token
+									name: configgin
 						-	name: "KUBERNETES_CLUSTER_DOMAIN"
 							value: "cluster.local"
 						-	name: "KUBERNETES_CONTAINER_NAME"

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -132,13 +132,14 @@ ln -s /var/vcap/packages /var/vcap/data/packages
 ln -s /var/vcap/sys /var/vcap/data/sys
 
 # Run custom environment scripts (that are sourced).
-{{ range $script := .instance_group.EnvironScripts }}
+{{- range $script := .instance_group.EnvironScripts }}
 source {{ script_path $script }}
-{{ end }}
+{{- end }}
+
 # Run custom role scripts.
-{{ range $script := .instance_group.Scripts }}
+{{- range $script := .instance_group.Scripts }}
 bash {{ script_path $script }}
-{{ end }}
+{{- end }}
 
 configgin \
   --jobs /opt/fissile/job_config.json \
@@ -146,9 +147,9 @@ configgin \
   --bosh-deployment-manifest /opt/fissile/config/deployment-manifest.yml
 
 # Unset all secrets
-{{ range $secret := .secrets }}
+{{- range $secret := .secrets }}
 unset {{ $secret }}
-{{ end }}
+{{- end }}
 
 if [ -e /etc/monitrc ]
 then
@@ -177,17 +178,17 @@ cron
 
 # Run custom post config role scripts.
 # Run any custom scripts other than pre-start.
-{{ range $script := .instance_group.PostConfigScripts }}
+{{- range $script := .instance_group.PostConfigScripts }}
 echo bash {{ script_path $script }}
 bash {{ script_path $script }}
-{{ end }}
+{{- end }}
 
 # Run pre-start scripts for each job.
-{{ range $job := .instance_group.JobReferences }}
+{{- range $job := .instance_group.JobReferences }}
 if [ -x /var/vcap/jobs/{{ $job.Name }}/bin/pre-start ] ; then
   /var/vcap/jobs/{{ $job.Name }}/bin/pre-start
 fi
-{{ end }}
+{{- end }}
 
 # Run
 {{ if eq .instance_group.Type "bosh-task" -}}

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -145,6 +145,11 @@ configgin \
   --env2conf /opt/fissile/env2conf.yml \
   --bosh-deployment-manifest /opt/fissile/config/deployment-manifest.yml
 
+# Unset all secrets
+{{ range $secret := .secrets }}
+unset {{ $secret }}
+{{ end }}
+
 if [ -e /etc/monitrc ]
 then
   chmod 0600 /etc/monitrc

--- a/test-assets/role-manifests/kube/pod-with-valid-pod-anti-affinity.yml
+++ b/test-assets/role-manifests/kube/pod-with-valid-pod-anti-affinity.yml
@@ -48,3 +48,10 @@ instance_groups:
                       values:
                       - istio-managed-group
                   topologyKey: "beta.kubernetes.io/os"
+configuration:
+  auth:
+    roles:
+      configgin: []
+    accounts:
+      default:
+        roles: [configgin]

--- a/test-assets/role-manifests/kube/pods.yml
+++ b/test-assets/role-manifests/kube/pods.yml
@@ -37,4 +37,10 @@ instance_groups:
         run:
           flight-stage: post-flight
           memory: 256
-
+configuration:
+  auth:
+    roles:
+      configgin: []
+    accounts:
+      default:
+        roles: [configgin]


### PR DESCRIPTION
It points to the `configgin` service account token in a secret named `configgin` updated by a `configgin-helper` job. This variable is not defined for pods already running with a service account that is bound to the `configgin` role because it would make no difference, and more importantly would prevent bootstrapping of `configgin-helper`.

[jsc#CAP-828]