### PR TITLE
Document cert subject names in values.yaml

### DIFF
--- a/kube/values.go
+++ b/kube/values.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"code.cloudfoundry.org/fissile/helm"
@@ -55,6 +56,25 @@ func MakeValues(settings ExportSettings) helm.Node {
 			}
 			if cv.CVOptions.Immutable {
 				comment += "\n" + thisValue + " is immutable and must not be changed once set."
+			}
+			if cv.Type == "certificate" && !cv.CVOptions.IsCA {
+				comment += "\nThis certificate uses the "
+				if cv.CVOptions.RoleName != "" {
+					comment += " role name " + strconv.Quote(cv.CVOptions.RoleName)
+					if cv.CVOptions.AltNames != nil {
+						comment += " and the additional"
+					}
+				} else if cv.CVOptions.AltNames == nil {
+					comment += " name " + strconv.Quote(util.ConvertNameToKey(name))
+				}
+				if cv.CVOptions.AltNames != nil {
+					if len(cv.CVOptions.AltNames) == 1 {
+						comment += " name " + strconv.Quote(cv.CVOptions.AltNames[0])
+					} else {
+						comment += " names " + util.WordList(util.QuoteList(cv.CVOptions.AltNames), "and")
+					}
+				}
+				comment += "."
 			}
 			comment += formattedExample(cv.CVOptions.Example)
 			if cv.Type == "" {

--- a/model/variables.go
+++ b/model/variables.go
@@ -45,6 +45,9 @@ type CVOptions struct {
 	Required      bool        `yaml:"required,omitempty"`
 	Immutable     bool        `yaml:"immutable,omitempty"`
 	ImageName     bool        `yaml:"imagename,omitempty"`
+	IsCA          bool        `yaml:"is_ca,omitempty"`
+	RoleName      string      `yaml:"role_name,omitempty"`
+	AltNames      []string    `yaml:"alternative_names,omitempty"`
 }
 
 // CVType is the type of the configuration variable; see the constants below

--- a/util/string_utils.go
+++ b/util/string_utils.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -21,6 +22,15 @@ func PrefixString(str, prefix, separator string) string {
 		return fmt.Sprintf("%s%s%s", prefix, separator, str)
 	}
 	return str
+}
+
+// QuoteList returns an array of quoted strings.
+func QuoteList(words []string) []string {
+	quoted := make([]string, len(words))
+	for i := range words {
+		quoted[i] = strconv.Quote(words[i])
+	}
+	return quoted
 }
 
 // WordList returns a string of all words in the 'words' slice. For 2 or more words the

--- a/util/string_utils_test.go
+++ b/util/string_utils_test.go
@@ -81,6 +81,37 @@ func TestPrefixString(t *testing.T) {
 	}
 }
 
+func TestQuoteList(t *testing.T) {
+	tests := []struct {
+		name     string
+		words    []string
+		expected []string
+	}{
+		{
+			name:     "empty list",
+			words:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "single word",
+			words:    []string{"foo"},
+			expected: []string{`"foo"`},
+		},
+		{
+			name:     "two words",
+			words:    []string{"foo", "bar"},
+			expected: []string{`"foo"`, `"bar"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := util.QuoteList(tt.words)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
 func TestWordList(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
In order to provide custom certs the user needs to know the subject names required for each cert. This commit adds them to the `values.yaml` file in the helm chart. For example:

```
  # PEM-encoded server certificate
  # This value uses a generated default.
  # This certificate uses the names "credhub-set" and
  # "server.dc1.{{.KUBERNETES_NAMESPACE}}.svc.{{.KUBERNETES_CLUSTER_DOMAIN}}".
  CREDHUB_SERVER_CERT: ~
```
Rules:

* The cert has neither role nor alternate names:
  This certificate uses the name "certificate-name".

* The cert has a role name but no alternate names:
  This certificate uses the role name "role".

* The cert has a role name and a single alternate name:
  This certificate uses the role name "role" and the additional name "alt".

* The cert has a role name and multiple alternate names:
  This certificate uses the role name "role" and the additional names "alt1", "alt2", and "alt3".

* The cert has no role but a single alternate name:
  This certificate uses the name "alt".

* The cert has no role but multiple alternate names:
  This certificate uses the names "alt1", "alt2", and "alt3".

The documentation will have to expand on how role names are mapped to a list of names, and which variables are used in template expansion.